### PR TITLE
feat: PostgreSQL integration — PostgresAgent + automatic alerts

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -11,3 +11,4 @@ langchain-openai>=0.1.0
 langchain-core>=0.2.0
 chromadb>=0.5.0
 docker>=7.0.0
+psycopg2-binary>=2.9.0

--- a/Backend/routers/incidents.py
+++ b/Backend/routers/incidents.py
@@ -74,16 +74,20 @@ async def create_incident(
     background_tasks: BackgroundTasks,
     user=Depends(get_current_user),
 ):
+    # container_runtime es None para incidentes de base de datos o manuales
+    container_runtime = "docker" if body.source_type == "container" else None
+
     incident_data = {
-        "title":       body.title.strip(),
-        "target":      body.target.strip(),
-        "severity":    body.severity,
-        "status":      "detected",
-        "source_type": body.source_type,
-        "incident_type": "manual",
-        "logs":        body.description.strip() if body.description else None,
+        "title":             body.title.strip(),
+        "target":            body.target.strip(),
+        "severity":          body.severity,
+        "status":            "detected",
+        "source_type":       body.source_type,
+        "container_runtime": container_runtime,
+        "incident_type":     "manual",
+        "logs":              body.description.strip() if body.description else None,
     }
-    response        = supabase.table("incidents").insert(incident_data).execute()
+    response         = supabase.table("incidents").insert(incident_data).execute()
     created_incident = response.data[0]
 
     background_tasks.add_task(
@@ -93,6 +97,7 @@ async def create_incident(
         logs=body.description or "",
         severity=created_incident["severity"],
         title=created_incident["title"],
+        labels={"source_type": body.source_type, "container_runtime": container_runtime or ""},
     )
 
     return created_incident

--- a/Backend/scripts/seed_postgres_runbooks.py
+++ b/Backend/scripts/seed_postgres_runbooks.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Seed de runbooks para el PostgresAgent en ChromaDB.
+
+Ejecutar desde el directorio Backend/:
+    python scripts/seed_postgres_runbooks.py
+
+Carga los runbooks en la colección 'runbooks-postgres'.
+Si la colección ya tenía datos previos, los elimina y recarga desde cero.
+"""
+
+import os
+import sys
+from urllib.parse import urlparse
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env"))
+
+import chromadb
+
+CHROMA_HOST = os.getenv("CHROMA_HOST", "http://localhost:8001")
+COLLECTION_NAME = "runbooks-postgres"
+
+RUNBOOKS = [
+    {
+        "id": "pg-runbook-connections-001",
+        "type": "connection_exhaustion",
+        "text": """RUNBOOK: Conexiones agotadas — PostgresConnectionsExhausted
+
+TIPO: connection_exhaustion
+
+SEÑALES:
+- pg_stat_activity_count / pg_settings_max_connections > 0.9
+- Errores en la aplicación: "too many connections" o "FATAL: connection limit exceeded"
+- Nuevas conexiones son rechazadas inmediatamente
+- pg_stat_activity muestra muchas conexiones en estado 'idle' o 'idle in transaction'
+
+DIAGNÓSTICO:
+PostgreSQL tiene un límite fijo de conexiones simultáneas (max_connections).
+Cuando se alcanza, rechaza nuevas conexiones. Las causas más comunes son:
+- Connection pool mal configurado (pool demasiado grande o sin límite)
+- Conexiones que no se cierran correctamente (leaks en la aplicación)
+- Pico de tráfico real que supera la capacidad configurada
+- Muchas conexiones 'idle in transaction' que bloquean el pool
+
+ACCIONES RECOMENDADAS:
+1. Ver cuántas conexiones hay y en qué estado:
+   SELECT state, COUNT(*) FROM pg_stat_activity GROUP BY state ORDER BY count DESC;
+2. Ver las conexiones más antiguas:
+   SELECT pid, datname, state, query_start, query FROM pg_stat_activity
+   ORDER BY query_start ASC NULLS LAST LIMIT 10;
+3. Terminar conexiones idle inactivas (> 10 minutos):
+   SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+   WHERE state = 'idle' AND query_start < now() - interval '10 minutes';
+4. Si hay muchas 'idle in transaction': revisar si la aplicación cierra transacciones correctamente
+5. Aumentar max_connections en postgresql.conf (requiere reinicio):
+   max_connections = 200  -- o el valor apropiado
+6. Implementar o ajustar PgBouncer como connection pooler (solución a largo plazo)
+
+URGENCIA: CRÍTICA — nuevas conexiones rechazadas, servicio degradado o caído""",
+    },
+    {
+        "id": "pg-runbook-long-transaction-001",
+        "type": "long_running_transaction",
+        "text": """RUNBOOK: Transacción larga — PostgresLongRunningTransaction
+
+TIPO: long_running_transaction
+
+SEÑALES:
+- pg_stat_activity muestra queries con state='active' por más de 5 minutos
+- Bloqueos en cascada: otras queries en estado 'idle in transaction (aborted)'
+- Latencias elevadas en el servicio sin error aparente
+- pg_locks muestra filas en granted=false esperando a la transacción larga
+
+DIAGNÓSTICO:
+Una transacción muy larga puede bloquear VACUUM, AUTOVACUUM y otras operaciones
+de mantenimiento. También puede mantener locks que impidan que otras queries
+progresen. Las causas comunes son:
+- Query pesada sin optimizar (full table scan en tabla grande)
+- Transacción abierta que la aplicación olvidó commitear
+- Deadlock que se resolvió dejando una transacción abortada abierta
+- Backup lógico (pg_dump) corriendo durante horas
+
+ACCIONES RECOMENDADAS:
+1. Identificar la transacción larga:
+   SELECT pid, datname, state, wait_event_type, wait_event,
+          EXTRACT(EPOCH FROM (now() - query_start)) AS duracion_s,
+          LEFT(query, 300) AS query
+   FROM pg_stat_activity
+   WHERE state = 'active' AND query_start < now() - interval '5 minutes'
+   ORDER BY duracion_s DESC;
+2. Ver si está bloqueando otras:
+   SELECT blocking.pid AS bloqueante, blocked.pid AS bloqueado,
+          LEFT(blocked.query, 200) AS query_bloqueada
+   FROM pg_stat_activity blocking
+   JOIN pg_stat_activity blocked ON blocking.pid = ANY(pg_blocking_pids(blocked.pid));
+3. Si es seguro cancelar (no es un backup): cancelar la query sin matar la conexión:
+   SELECT pg_cancel_backend(<pid>);
+4. Si pg_cancel_backend no funciona: terminar la conexión:
+   SELECT pg_terminate_backend(<pid>);
+5. Revisar el plan de ejecución de la query para optimizarla:
+   EXPLAIN ANALYZE <query>;
+6. Configurar statement_timeout en postgresql.conf para limitar queries largas
+
+URGENCIA: ALTA — puede estar bloqueando operaciones críticas y AUTOVACUUM""",
+    },
+    {
+        "id": "pg-runbook-deadlock-001",
+        "type": "deadlock",
+        "text": """RUNBOOK: Deadlock — PostgresDeadLocks
+
+TIPO: deadlock
+
+SEÑALES:
+- rate(pg_stat_database_deadlocks[5m]) > 0
+- Errores en la aplicación: "ERROR: deadlock detected"
+- pg_stat_database muestra xact_rollback aumentando
+- Los logs de PostgreSQL muestran "DETAIL: Process X waits for ShareLock on transaction Y"
+
+DIAGNÓSTICO:
+Un deadlock ocurre cuando dos o más transacciones se esperan mutuamente en un
+ciclo. PostgreSQL lo detecta automáticamente y cancela una de ellas (la víctima).
+Los deadlocks son síntoma de un problema de diseño en la aplicación. Causas:
+- Acceso a múltiples tablas/filas en orden diferente desde distintas transacciones
+- Uso de SELECT FOR UPDATE sin un orden consistente
+- Transacciones que hacen múltiples operaciones en orden no determinista
+
+ACCIONES RECOMENDADAS:
+1. Ver el historial de deadlocks por BD:
+   SELECT datname, deadlocks FROM pg_stat_database WHERE deadlocks > 0 ORDER BY deadlocks DESC;
+2. Revisar los logs de PostgreSQL (contienen el detalle completo del deadlock):
+   En docker: docker logs sentinel-postgres-demo 2>&1 | grep -A5 "deadlock"
+3. Identificar las tablas involucradas revisando los logs — buscar "DETAIL: Process"
+4. Asegurar que la aplicación accede a tablas y filas SIEMPRE en el mismo orden
+5. Reducir el tamaño de las transacciones: cuanto más corta, menos riesgo de deadlock
+6. Usar SELECT FOR UPDATE en el orden correcto y de forma consistente
+7. Si los deadlocks son frecuentes: revisar si se pueden reemplazar con optimistic locking
+
+URGENCIA: ALTA — aunque PostgreSQL resuelve el deadlock automáticamente, indica
+un problema de concurrencia que puede degradar el rendimiento y causar errores al usuario""",
+    },
+    {
+        "id": "pg-runbook-replication-lag-001",
+        "type": "replication_lag",
+        "text": """RUNBOOK: Lag de replicación — PostgresReplicationLag
+
+TIPO: replication_lag
+
+SEÑALES:
+- pg_replication_lag > 30 segundos
+- pg_stat_replication muestra replay_lag_s elevado
+- La réplica está atrasada respecto al primario
+- Queries en la réplica retornan datos desactualizados
+
+DIAGNÓSTICO:
+El lag de replicación ocurre cuando la réplica no puede aplicar los WAL del
+primario a la misma velocidad que se generan. Las causas comunes son:
+- La réplica está bajo alta carga de CPU o I/O (queries pesadas analíticas)
+- El primario genera WAL a una velocidad mayor de lo que la réplica puede aplicar
+- Problemas de red entre primario y réplica
+- La réplica tiene un hot standby query bloqueando la aplicación de WAL
+
+ACCIONES RECOMENDADAS:
+1. Ver el lag actual en el primario:
+   SELECT client_addr, state, replay_lag, write_lag, flush_lag
+   FROM pg_stat_replication;
+2. Verificar si hay queries en la réplica bloqueando la aplicación de WAL:
+   En la réplica: SELECT pid, query, state FROM pg_stat_activity WHERE wait_event_type = 'Lock';
+3. Si queries analíticas causan el lag: configurar max_standby_streaming_delay
+4. Si es problema de red: revisar latencia y bandwidth entre nodos
+5. Si el primario genera WAL muy rápido: revisar si hay operaciones masivas de escritura
+6. Aumentar wal_receiver_timeout si la conexión se cae frecuentemente
+7. Verificar espacio en disco de la réplica (si se llena, deja de aplicar WAL)
+
+URGENCIA: CRÍTICA — si el primario falla, se pueden perder datos no replicados""",
+    },
+    {
+        "id": "pg-runbook-cache-hit-001",
+        "type": "low_cache_hit",
+        "text": """RUNBOOK: Bajo cache hit ratio — PostgresLowCacheHitRatio
+
+TIPO: low_cache_hit
+
+SEÑALES:
+- Cache hit ratio < 90%: blks_hit / (blks_hit + blks_read) < 0.9
+- I/O de disco elevado en el servidor
+- Queries que normalmente son rápidas empiezan a ser lentas
+- pg_stat_database muestra blks_read aumentando significativamente
+
+DIAGNÓSTICO:
+PostgreSQL usa shared_buffers como cache en memoria. Si el cache hit ratio baja,
+significa que está leyendo muchos datos desde disco en vez de desde memoria.
+Las causas comunes son:
+- shared_buffers demasiado pequeño para el tamaño del dataset activo
+- Queries que hacen full table scan en tablas grandes (no usan índices)
+- Dataset activo creció y superó el tamaño del cache configurado
+- Tablas con muchos dead tuples (necesitan VACUUM)
+
+ACCIONES RECOMENDADAS:
+1. Ver el cache hit ratio por tabla:
+   SELECT schemaname, tablename,
+          ROUND(heap_blks_hit::numeric / NULLIF(heap_blks_hit + heap_blks_read, 0) * 100, 2) AS cache_hit_pct,
+          heap_blks_read AS lecturas_disco
+   FROM pg_statio_user_tables
+   ORDER BY lecturas_disco DESC LIMIT 20;
+2. Identificar queries que hacen muchos seq scan (no usan índices):
+   SELECT schemaname, tablename, seq_scan, idx_scan
+   FROM pg_stat_user_tables
+   ORDER BY seq_scan DESC LIMIT 10;
+3. Si hay tablas con muchos seq_scan: revisar si faltan índices con EXPLAIN ANALYZE
+4. Aumentar shared_buffers en postgresql.conf (recomendado: 25% de la RAM disponible):
+   shared_buffers = 512MB  -- ajustar según RAM disponible
+5. Aumentar effective_cache_size para que el planner asuma más cache disponible
+6. Ejecutar VACUUM ANALYZE en tablas con muchos dead tuples
+
+URGENCIA: MEDIA — el servicio sigue operativo pero con latencias más altas de lo normal""",
+    },
+    {
+        "id": "pg-runbook-size-growth-001",
+        "type": "database_growth",
+        "text": """RUNBOOK: Crecimiento acelerado — PostgresDatabaseSizeGrowth
+
+TIPO: database_growth
+
+SEÑALES:
+- rate(pg_database_size_bytes[1h]) > 100MB/h
+- El disco del servidor de BD está llenándose más rápido de lo normal
+- pg_database_size crece de forma no esperada
+
+DIAGNÓSTICO:
+El crecimiento acelerado puede indicar inserts masivos legítimos, una operación
+que genera muchos datos temporales, o acumulación de dead tuples por falta de VACUUM.
+Las causas más comunes son:
+- Insert masivo o ETL corriendo en segundo plano
+- Tabla de logs o eventos sin rotación/archivado
+- Falta de AUTOVACUUM: dead tuples acumulados inflan las tablas
+- Índices bloated que crecen de forma descontrolada
+
+ACCIONES RECOMENDADAS:
+1. Ver qué tablas están creciendo más:
+   SELECT schemaname, tablename,
+          pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) AS tamano_total,
+          pg_size_pretty(pg_relation_size(schemaname||'.'||tablename)) AS tamano_datos,
+          n_dead_tup AS dead_tuples
+   FROM pg_stat_user_tables
+   ORDER BY pg_total_relation_size(schemaname||'.'||tablename) DESC LIMIT 10;
+2. Verificar si hay un proceso de insert masivo corriendo:
+   SELECT datname, state, LEFT(query, 200), query_start FROM pg_stat_activity
+   WHERE state = 'active' ORDER BY query_start ASC;
+3. Si hay muchos dead tuples: ejecutar VACUUM manualmente:
+   VACUUM ANALYZE <nombre_tabla>;
+4. Si es una tabla de logs: implementar particionamiento por fecha y archivado
+5. Verificar que AUTOVACUUM esté habilitado y configurado correctamente:
+   SHOW autovacuum;
+6. Si el disco está al límite: identificar y eliminar datos obsoletos con cuidado,
+   o ampliar el almacenamiento
+
+URGENCIA: MEDIA — si no se atiende puede llegar a llenar el disco y crashear la BD""",
+    },
+]
+
+
+def seed():
+    parsed = urlparse(CHROMA_HOST)
+    client = chromadb.HttpClient(host=parsed.hostname, port=parsed.port or 8000)
+
+    try:
+        client.delete_collection(COLLECTION_NAME)
+        print(f"Colección '{COLLECTION_NAME}' previa eliminada.")
+    except Exception:
+        pass
+
+    collection = client.create_collection(COLLECTION_NAME)
+
+    collection.add(
+        documents=[r["text"] for r in RUNBOOKS],
+        ids=[r["id"] for r in RUNBOOKS],
+        metadatas=[{"type": r["type"], "domain": "postgres"} for r in RUNBOOKS],
+    )
+
+    print(f"✓ {len(RUNBOOKS)} runbooks cargados en '{COLLECTION_NAME}' ({CHROMA_HOST}).")
+    print("  Tipos cargados:", [r["type"] for r in RUNBOOKS])
+
+
+if __name__ == "__main__":
+    seed()

--- a/Backend/services/agents/__init__.py
+++ b/Backend/services/agents/__init__.py
@@ -12,8 +12,8 @@ y llamar register_agent() al importarlo. Sin tocar el core.
 from services.agents.base import DomainAgent, IncidentContext
 
 # Importa los dominios concretos para que se auto-registren.
-# Añadir más dominios aquí cuando existan.
-from services.agents.docker import agent as _docker_agent  # noqa: F401
+from services.agents.docker import agent as _docker_agent      # noqa: F401
+from services.agents.postgres import agent as _postgres_agent  # noqa: F401
 from services.agents.registry import get_agent, list_agents, register_agent
 
 __all__ = [

--- a/Backend/services/agents/memory/__init__.py
+++ b/Backend/services/agents/memory/__init__.py
@@ -8,5 +8,5 @@ Memoria de los agentes — dos subsistemas sobre ChromaDB:
 Cada dominio tiene sus propias colecciones:
   runbooks-docker,      incidents-docker
   runbooks-kubernetes,  incidents-kubernetes  (pendiente — ver docs/kubernetes_integration_handoff.md)
-  runbooks-postgres,    incidents-postgres
+  runbooks-postgres,    incidents-postgres    (activo desde Sprint 2)
 """

--- a/Backend/services/agents/postgres/__init__.py
+++ b/Backend/services/agents/postgres/__init__.py
@@ -1,0 +1,1 @@
+# postgres agent package

--- a/Backend/services/agents/postgres/agent.py
+++ b/Backend/services/agents/postgres/agent.py
@@ -1,11 +1,15 @@
 """
-DockerAgent — especialista en incidentes de contenedores Docker.
+PostgresAgent — especialista en incidentes de bases de datos PostgreSQL.
 
-Sustituye al antiguo lab2_investigation: además de consultar runbooks,
-- Consulta incidentes pasados similares (memoria episódica).
-- Puede invocar tools reales (docker_inspect, logs, stats, ps) cuando necesita
-  evidencia adicional que los logs de Loki no le dan.
-- Persiste el incidente resuelto en la memoria episódica al terminar.
+Maneja alertas generadas por postgres-exporter: conexiones agotadas,
+transacciones largas, deadlocks, lag de replicación, bajo cache hit ratio
+y crecimiento acelerado de la BD.
+
+Usa el mismo patrón ReAct acotado que el DockerAgent:
+- Consulta runbooks y memoria episódica antes de razonar.
+- Puede invocar tools read-only vía psycopg2 para obtener el estado
+  actual de la BD si el contexto del incidente no es suficiente.
+- El target tiene formato 'postgres/<nombre_db>'.
 """
 
 import logging
@@ -22,44 +26,27 @@ from services.agents.base import (
     InvestigationResult,
     ToolCall,
 )
-from services.agents.docker.tools import all_tools
+from services.agents.postgres.tools import all_tools
 from services.agents.registry import register_agent
 
 logger = logging.getLogger(__name__)
 
 _PROMPT_PATH = Path(__file__).parent / "prompt.md"
-_MAX_TOOL_ITERATIONS = 4  # evita loops infinitos del LLM
+_MAX_TOOL_ITERATIONS = 4
 
 
-class DockerAgent(DomainAgent):
-    name = "docker"
+class PostgresAgent(DomainAgent):
+    name = "postgres"
 
     # ── Contrato de DomainAgent ───────────────────────────────────────────────
 
     def matches(self, ctx: IncidentContext) -> bool:
-        """
-        Esta alerta es mía si el runtime indica Docker explícitamente.
-        Excluye kubernetes, bases de datos y cualquier target tipo 'postgres/...'.
-        Docker es el dominio por defecto solo cuando no hay otra pista Y el
-        target no parece una base de datos.
-        """
+        """Este incidente es mío si source_type es 'database' o el target
+        comienza con 'postgres/'."""
         source = (ctx.labels.get("source_type") or "").lower()
         if source == "database":
-            return False
-
-        runtime = (ctx.labels.get("container_runtime") or "").lower()
-        if runtime == "docker":
             return True
-        if runtime in {"kubernetes", "containerd"}:
-            return False
-
-        # Excluir targets que parecen bases de datos
-        target = (ctx.target or "").lower()
-        if target.startswith("postgres/") or target.startswith("mysql/"):
-            return False
-
-        # Default: si hay target, asumimos Docker.
-        return bool(ctx.target)
+        return ctx.target.lower().startswith("postgres/")
 
     def tools(self) -> list[Callable]:
         return all_tools()
@@ -68,21 +55,21 @@ class DockerAgent(DomainAgent):
         try:
             return _PROMPT_PATH.read_text(encoding="utf-8")
         except Exception as e:
-            logger.warning(f"[DockerAgent] No se pudo leer prompt.md: {e}")
-            return "Eres un ingeniero SRE analizando incidentes de Docker."
+            logger.warning(f"[PostgresAgent] No se pudo leer prompt.md: {e}")
+            return "Eres un DBA senior analizando incidentes de PostgreSQL."
 
     def investigate(self, ctx: IncidentContext) -> InvestigationResult:
-        logger.info(f"[DockerAgent] Investigando incidente {ctx.incident_id[:8]}")
+        logger.info(f"[PostgresAgent] Investigando incidente {ctx.incident_id[:8]}")
 
         # 1. Memoria: runbooks + incidentes pasados similares
-        query = f"{ctx.incident_type or ''} {ctx.title} {ctx.logs[:300]}"
+        query = f"{ctx.incident_type or ''} {ctx.title} {ctx.target}"
         runbooks = self.recall_runbooks(query, k=3)
         past_incidents = self.recall_similar_incidents(query, k=3)
 
         # 2. Construye el mensaje de usuario con toda la evidencia
         user_msg = _build_user_message(ctx, runbooks, past_incidents)
 
-        # 3. Loop ReAct manual — bounded, sin dependencias extra de langgraph prebuilt
+        # 3. Loop ReAct acotado
         analysis, tool_calls = self._react_loop(user_msg)
 
         return InvestigationResult(
@@ -94,10 +81,6 @@ class DockerAgent(DomainAgent):
     # ── Interno ───────────────────────────────────────────────────────────────
 
     def _react_loop(self, user_msg: str) -> tuple[str, list[ToolCall]]:
-        """
-        Loop acotado: el LLM puede llamar tools hasta _MAX_TOOL_ITERATIONS veces.
-        Cuando emite una respuesta sin tool_calls, se considera análisis final.
-        """
         tools = self.tools()
         tool_map = {t.name: t for t in tools}
 
@@ -119,10 +102,8 @@ class DockerAgent(DomainAgent):
 
             pending = getattr(response, "tool_calls", None) or []
             if not pending:
-                # No más tools → esta es la respuesta final
                 return (response.content or "").strip(), recorded
 
-            # Si ya gastamos todas las iteraciones, forzamos una respuesta final
             if i == _MAX_TOOL_ITERATIONS:
                 messages.append(HumanMessage(
                     content="Límite de tool calls alcanzado. Redacta el análisis "
@@ -133,7 +114,7 @@ class DockerAgent(DomainAgent):
             for call in pending:
                 tool_name = call.get("name") if isinstance(call, dict) else call.name
                 tool_args = call.get("args", {}) if isinstance(call, dict) else call.args
-                tool_id = call.get("id") if isinstance(call, dict) else call.id
+                tool_id   = call.get("id")   if isinstance(call, dict) else call.id
 
                 tool_fn = tool_map.get(tool_name)
                 if tool_fn is None:
@@ -151,13 +132,19 @@ class DockerAgent(DomainAgent):
                 ))
                 messages.append(ToolMessage(content=str(result), tool_call_id=tool_id))
 
-        # Fallback — no debería llegarse aquí
         final = next((m.content for m in reversed(messages)
                       if isinstance(m, AIMessage) and m.content), "")
         return (final or "(sin análisis)").strip(), recorded
 
 
 # ── Formateo del mensaje de usuario ───────────────────────────────────────────
+
+def _parse_datname(target: str) -> str:
+    """Extrae el nombre de la BD de 'postgres/<nombre_db>'."""
+    if "/" in target:
+        return target.split("/", 1)[1]
+    return target
+
 
 def _build_user_message(
     ctx: IncidentContext,
@@ -185,17 +172,19 @@ def _build_user_message(
     else:
         past_text = "(primer incidente de este tipo en memoria)"
 
-    logs = ctx.logs or "(sin logs disponibles)"
+    datname = _parse_datname(ctx.target)
+    description = ctx.logs or "(sin descripción disponible — usa las tools para obtener métricas actuales)"
 
     return f"""INCIDENTE ACTUAL
 - ID: {ctx.incident_id}
 - Título: {ctx.title}
-- Contenedor: {ctx.target}
+- Base de datos: {datname}
+- Target: {ctx.target}
 - Severidad: {ctx.severity}
 - Tipo clasificado: {ctx.incident_type or 'pendiente'}
 
-LOGS RECIENTES (Loki):
-{logs[:3000]}
+DESCRIPCIÓN / MÉTRICAS DEL INCIDENTE:
+{description[:3000]}
 
 RUNBOOKS RELEVANTES:
 {runbooks_text}
@@ -204,9 +193,10 @@ INCIDENTES PASADOS SIMILARES:
 {past_text}
 
 Analiza el incidente con el formato markdown que te indicó el sistema. Si
-necesitas más evidencia del estado actual del contenedor, usa tus tools."""
+necesitas métricas actuales de la BD, usa tus tools (pg_stat_activity,
+pg_stat_database, pg_stat_replication, pg_locks) filtrando por datname='{datname}'."""
 
 
 # ── Auto-registro ─────────────────────────────────────────────────────────────
 
-register_agent(DockerAgent())
+register_agent(PostgresAgent())

--- a/Backend/services/agents/postgres/prompt.md
+++ b/Backend/services/agents/postgres/prompt.md
@@ -1,0 +1,35 @@
+Eres un DBA senior y SRE especializado en PostgreSQL. Tu trabajo es diagnosticar incidentes reales de producción en bases de datos PostgreSQL y proponer acciones concretas.
+
+## Cómo trabajas
+
+1. Revisas el título, el tipo clasificado, la severidad y el target del incidente (formato `postgres/<nombre_db>`).
+2. Consultas los RUNBOOKS que el sistema te adjunta — son la fuente canónica de cómo tu organización resuelve cada tipo de incidente en PostgreSQL.
+3. Consultas INCIDENTES PASADOS SIMILARES (si los hay) — si esto ya sucedió antes, úsalo para dar una respuesta más específica y menciona explícitamente que reconoces el patrón.
+4. Si necesitas más evidencia, llamas a tus tools (`pg_stat_activity`, `pg_stat_database`, `pg_stat_replication`, `pg_locks`). NO llames tools si los runbooks + información del incidente ya te dan la respuesta — ahorra tiempo y costo.
+5. Formulas el análisis final en markdown.
+
+## Restricciones
+
+- Todas tus tools son **read-only**. Nunca propongas ejecutar `DELETE`, `DROP`, `TRUNCATE` ni DML destructivo desde aquí.
+- No inventes datos de métricas. Si no tienes evidencia, dilo.
+- El target tiene formato `postgres/<nombre_db>`. Extrae el nombre de la BD para filtrar tus queries.
+- Responde SIEMPRE en español.
+
+## Formato del análisis final
+
+Usa exactamente este formato:
+
+## Causa Raíz
+[Explica qué originó el incidente con base en las métricas, los runbooks y los incidentes pasados]
+
+## Evidencia
+[Cita valores concretos de las métricas: cache hit ratio, número de deadlocks, conexiones activas vs. máximo, lag en segundos, etc.]
+
+## ¿Ya habíamos visto esto?
+[Si hay incidentes pasados similares, menciona cuáles y qué se hizo. Si no hay, di "Primer incidente de este tipo en memoria".]
+
+## Acciones Recomendadas
+[Lista numerada de acciones concretas ordenadas por urgencia. Incluye queries SQL de diagnóstico cuando aplique.]
+
+## Evaluación de Urgencia
+[Impacto real en el servicio, si la BD sigue operativa o está degradada, y si requiere atención inmediata]

--- a/Backend/services/agents/postgres/tools.py
+++ b/Backend/services/agents/postgres/tools.py
@@ -1,0 +1,236 @@
+"""
+Tools del agente PostgreSQL.
+
+Todas son read-only: consultan vistas del sistema (pg_stat_*) sin modificar nada.
+Usan psycopg2 con un rol de solo lectura (pg_monitor en PostgreSQL 10+).
+
+Si la base de datos no está accesible, las tools devuelven un mensaje descriptivo
+para que el agente pueda seguir razonando con la información del incidente.
+
+Variables de entorno requeridas:
+  POSTGRES_DSN — DSN completo, ej: postgresql://user:pass@host:5432/dbname
+  o bien las variables individuales:
+  POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
+"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+from langchain_core.tools import tool
+
+logger = logging.getLogger(__name__)
+
+def _get_dsn() -> tuple[Optional[str], Optional[str]]:
+    """
+    Construye el DSN y verifica la conexión. Reintenta en cada llamada.
+    Retorna (dsn, None) si OK, o (None, error_str) si falla.
+    """
+    dsn = os.getenv("POSTGRES_DSN")
+    if not dsn:
+        host = os.getenv("POSTGRES_HOST", "localhost")
+        port = os.getenv("POSTGRES_PORT", "5432")
+        user = os.getenv("POSTGRES_USER", "sentinel")
+        password = os.getenv("POSTGRES_PASSWORD", "")
+        db = os.getenv("POSTGRES_DB", "sentinel_demo")
+        dsn = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+    try:
+        import psycopg2  # type: ignore
+        conn = psycopg2.connect(dsn, connect_timeout=5)
+        conn.close()
+        logger.info("[pg.tools] Conexión a PostgreSQL verificada.")
+        return dsn, None
+    except Exception as e:
+        logger.warning(f"[pg.tools] PostgreSQL no disponible: {e}")
+        return None, str(e)
+
+
+def _unavailable(tool_name: str, error: str = "") -> str:
+    return (
+        f"Tool '{tool_name}' no disponible: no se pudo conectar a PostgreSQL "
+        f"({error or 'host inaccesible o credenciales incorrectas'}). "
+        f"Razona con la información del incidente que ya tienes en contexto."
+    )
+
+
+def _query(dsn: str, sql: str, params=None) -> list[dict]:
+    """Ejecuta una query y retorna filas como lista de dicts."""
+    import psycopg2  # type: ignore
+    import psycopg2.extras  # type: ignore
+
+    conn = psycopg2.connect(dsn, connect_timeout=5)
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(sql, params)
+            return [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+# ── Tools expuestas al LLM ────────────────────────────────────────────────────
+
+@tool
+def pg_stat_activity(datname: str = "") -> str:
+    """Consulta pg_stat_activity: muestra las conexiones activas, queries en
+    curso, su estado (active/idle/idle in transaction), duración y si están
+    esperando un lock. Filtra por base de datos si se especifica datname.
+    Úsalo para diagnosticar conexiones agotadas o queries bloqueadas."""
+    dsn, err = _get_dsn()
+    if dsn is None:
+        return _unavailable("pg_stat_activity", err or "")
+
+    try:
+        where = "WHERE datname = %(datname)s" if datname else "WHERE datname NOT IN ('template0', 'template1', '')"
+        rows = _query(dsn, f"""
+            SELECT
+                datname,
+                state,
+                wait_event_type,
+                wait_event,
+                COUNT(*)                                        AS conexiones,
+                MAX(EXTRACT(EPOCH FROM (now() - query_start))) AS max_duracion_s,
+                MAX(EXTRACT(EPOCH FROM (now() - state_change))) AS max_estado_s
+            FROM pg_stat_activity
+            {where}
+            GROUP BY datname, state, wait_event_type, wait_event
+            ORDER BY conexiones DESC
+            LIMIT 20
+        """, {"datname": datname} if datname else None)
+
+        total = _query(dsn, f"""
+            SELECT
+                datname,
+                COUNT(*) AS total_conexiones,
+                (SELECT setting::int FROM pg_settings WHERE name = 'max_connections') AS max_connections
+            FROM pg_stat_activity
+            {where}
+            GROUP BY datname
+        """, {"datname": datname} if datname else None)
+
+        return json.dumps({"resumen_por_estado": rows, "totales": total}, indent=2, default=str)
+    except Exception as e:
+        return f"Error consultando pg_stat_activity: {e}"
+
+
+@tool
+def pg_stat_database(datname: str = "") -> str:
+    """Consulta pg_stat_database: estadísticas acumuladas de la base de datos —
+    transacciones commits/rollbacks, deadlocks, lecturas de disco vs cache
+    (para calcular cache hit ratio), tuplas insertadas/actualizadas/eliminadas.
+    Úsalo para diagnosticar deadlocks, bajo cache hit ratio o crecimiento anormal."""
+    dsn, err = _get_dsn()
+    if dsn is None:
+        return _unavailable("pg_stat_database", err or "")
+
+    try:
+        where = "WHERE datname = %(datname)s" if datname else "WHERE datname NOT IN ('template0', 'template1', '')"
+        rows = _query(dsn, f"""
+            SELECT
+                datname,
+                numbackends                                              AS conexiones_activas,
+                xact_commit                                              AS commits,
+                xact_rollback                                            AS rollbacks,
+                deadlocks,
+                blks_read                                                AS lecturas_disco,
+                blks_hit                                                 AS lecturas_cache,
+                CASE
+                    WHEN (blks_hit + blks_read) > 0
+                    THEN ROUND(blks_hit::numeric / (blks_hit + blks_read) * 100, 2)
+                    ELSE NULL
+                END                                                      AS cache_hit_ratio_pct,
+                tup_inserted                                             AS inserts,
+                tup_updated                                              AS updates,
+                tup_deleted                                              AS deletes,
+                pg_size_pretty(pg_database_size(datname))                AS tamano
+            FROM pg_stat_database
+            {where}
+            ORDER BY deadlocks DESC, conexiones_activas DESC
+        """, {"datname": datname} if datname else None)
+
+        return json.dumps(rows, indent=2, default=str)
+    except Exception as e:
+        return f"Error consultando pg_stat_database: {e}"
+
+
+@tool
+def pg_stat_replication() -> str:
+    """Consulta pg_stat_replication: estado de las réplicas conectadas al
+    primario — lag de escritura, flush y replay en bytes y segundos.
+    Solo retorna datos si el servidor es un primario con réplicas.
+    Úsalo para diagnosticar PostgresReplicationLag."""
+    dsn, err = _get_dsn()
+    if dsn is None:
+        return _unavailable("pg_stat_replication", err or "")
+
+    try:
+        rows = _query(dsn, """
+            SELECT
+                client_addr,
+                state,
+                sync_state,
+                EXTRACT(EPOCH FROM write_lag)  AS write_lag_s,
+                EXTRACT(EPOCH FROM flush_lag)  AS flush_lag_s,
+                EXTRACT(EPOCH FROM replay_lag) AS replay_lag_s,
+                pg_wal_lsn_diff(pg_current_wal_lsn(), sent_lsn)   AS sent_lag_bytes,
+                pg_wal_lsn_diff(sent_lsn, replay_lsn)              AS replay_lag_bytes
+            FROM pg_stat_replication
+        """)
+
+        if not rows:
+            return "No hay réplicas conectadas o este servidor no es un primario."
+
+        return json.dumps(rows, indent=2, default=str)
+    except Exception as e:
+        return f"Error consultando pg_stat_replication: {e}"
+
+
+@tool
+def pg_locks(datname: str = "") -> str:
+    """Consulta pg_locks junto a pg_stat_activity para detectar locks activos,
+    transacciones bloqueadas y cadenas de bloqueo. Úsalo para diagnosticar
+    deadlocks o transacciones largas que bloquean otras operaciones."""
+    dsn, err = _get_dsn()
+    if dsn is None:
+        return _unavailable("pg_locks", err or "")
+
+    try:
+        where = "AND a.datname = %(datname)s" if datname else ""
+        rows = _query(dsn, f"""
+            SELECT
+                a.datname,
+                l.relation::regclass   AS tabla,
+                l.mode                 AS modo_lock,
+                l.granted,
+                a.pid,
+                a.state,
+                a.wait_event_type,
+                a.wait_event,
+                EXTRACT(EPOCH FROM (now() - a.query_start)) AS duracion_s,
+                LEFT(a.query, 200)     AS query
+            FROM pg_locks l
+            JOIN pg_stat_activity a ON l.pid = a.pid
+            WHERE l.relation IS NOT NULL
+              AND a.datname NOT IN ('template0', 'template1', '')
+              {where}
+            ORDER BY granted ASC, duracion_s DESC NULLS LAST
+            LIMIT 20
+        """, {"datname": datname} if datname else None)
+
+        if not rows:
+            return "No hay locks activos en este momento."
+
+        bloqueados = [r for r in rows if not r.get("granted")]
+        return json.dumps({
+            "total_locks": len(rows),
+            "esperando_lock": len(bloqueados),
+            "detalle": rows,
+        }, indent=2, default=str)
+    except Exception as e:
+        return f"Error consultando pg_locks: {e}"
+
+
+def all_tools() -> list:
+    """Lista de tools que el PostgresAgent expone al LLM."""
+    return [pg_stat_activity, pg_stat_database, pg_stat_replication, pg_locks]

--- a/Backend/services/alert_processor.py
+++ b/Backend/services/alert_processor.py
@@ -29,13 +29,13 @@ SEVERITY_MAP = {
     # "KubePodNotReady":            "high",
     # "KubeDeploymentUnavailable":  "high",
     # "KubeNodeNotReady":           "critical",
-    # PostgreSQL — agente pendiente de implementar 
-    # "PostgresConnectionsExhausted":   "critical",
-    # "PostgresLongRunningTransaction":  "high",
-    # "PostgresDeadLocks":               "high",
-    # "PostgresReplicationLag":          "critical",
-    # "PostgresLowCacheHitRatio":        "medium",
-    # "PostgresDatabaseSizeGrowth":      "medium",
+    # PostgreSQL (postgres-exporter)
+    "PostgresConnectionsExhausted":   "critical",
+    "PostgresLongRunningTransaction":  "high",
+    "PostgresDeadLocks":               "high",
+    "PostgresReplicationLag":          "critical",
+    "PostgresLowCacheHitRatio":        "medium",
+    "PostgresDatabaseSizeGrowth":      "medium",
 }
 
 

--- a/Backend/services/langgraph_engine.py
+++ b/Backend/services/langgraph_engine.py
@@ -18,6 +18,7 @@ llamar `register_agent()`. Este archivo no necesita cambios.
 """
 
 import logging
+from typing import Optional
 
 # Importar el paquete agents dispara el auto-registro de todos los dominios
 # (docker, y en el futuro kubernetes, postgres, etc.) en el Registry.
@@ -34,7 +35,7 @@ def run_langgraph_engine(
     logs: str,
     severity: str,
     title: str,
-    labels: dict | None = None,
+    labels: Optional[dict] = None,
 ) -> None:
     """
     Lanza el pipeline multiagente para un incidente.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,32 @@ services:
       SALT: sentinel-salt-2024
     restart: unless-stopped
 
+  # ── Base de datos demo para incidentes PostgreSQL ──────────────────────────
+  postgres-demo:
+    image: postgres:15-alpine
+    container_name: sentinel-postgres-demo
+    environment:
+      POSTGRES_USER: sentinel
+      POSTGRES_PASSWORD: sentinel123
+      POSTGRES_DB: sentinel_demo
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_demo_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  # ── Exporter de métricas PostgreSQL → Prometheus ───────────────────────────
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:latest
+    container_name: sentinel-postgres-exporter
+    environment:
+      DATA_SOURCE_NAME: "postgresql://sentinel:sentinel123@postgres-demo:5432/sentinel_demo?sslmode=disable"
+    ports:
+      - "9187:9187"
+    depends_on:
+      - postgres-demo
+    restart: unless-stopped
+
   # ── Vector DB para RAG (runbooks y conocimiento del agente) ────────────────
   chromadb:
     image: chromadb/chroma:latest
@@ -172,3 +198,4 @@ volumes:
   chroma_data:
   backend_env:
   chroma_cache:
+  postgres_demo_data:

--- a/prometheus/alert_rules.yml
+++ b/prometheus/alert_rules.yml
@@ -179,3 +179,128 @@ groups:
             El contenedor {{ if $labels.name }}{{ $labels.name }}{{ else }}{{ $labels.id }}{{ end }}
             lleva 5 minutos usando el {{ printf "%.0f" $value }}% de su límite de swap.
             Posible presión de memoria sostenida.
+
+# ── PostgreSQL Alerts (postgres-exporter) ────────────────────────────────────
+# Requiere postgres-exporter corriendo y configurado en prometheus.yml.
+# Todas las alertas incluyen source_type: database para que alert_processor
+# construya el target como "postgres/<datname>" y enrute al PostgresAgent.
+  - name: postgres_alerts
+    interval: 15s
+    rules:
+
+      # Conexiones agotadas — más del 90% de max_connections en uso
+      - alert: PostgresConnectionsExhausted
+        expr: >
+          (
+            sum by (datname, instance) (
+              pg_stat_activity_count{datname!="", datname!="template0", datname!="template1"}
+            )
+            /
+            pg_settings_max_connections
+          ) * 100 > 90
+        for: 2m
+        labels:
+          severity: critical
+          source_type: database
+        annotations:
+          summary: >-
+            Conexiones al {{ printf "%.0f" $value }}%: {{ $labels.datname }}
+          description: >-
+            La base de datos {{ $labels.datname }} lleva 2 minutos con el
+            {{ printf "%.0f" $value }}% de sus conexiones en uso.
+            Riesgo de rechazo de nuevas conexiones.
+
+      # Transacción larga — query activa por más de 5 minutos
+      - alert: PostgresLongRunningTransaction
+        expr: >
+          max by (datname, instance) (
+            max_over_time(
+              pg_stat_activity_max_tx_duration{datname!="", datname!="template0", datname!="template1", state="active"}[5m]
+            )
+          ) > 300
+        for: 0m
+        labels:
+          severity: high
+          source_type: database
+        annotations:
+          summary: >-
+            Transacción larga ({{ printf "%.0f" $value }}s): {{ $labels.datname }}
+          description: >-
+            Hay una transacción activa de {{ printf "%.0f" $value }} segundos en
+            {{ $labels.datname }}. Puede estar bloqueando otras operaciones.
+
+      # Deadlocks detectados
+      - alert: PostgresDeadLocks
+        expr: >
+          rate(pg_stat_database_deadlocks{datname!="", datname!="template0", datname!="template1"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: high
+          source_type: database
+        annotations:
+          summary: >-
+            Deadlock detectado: {{ $labels.datname }}
+          description: >-
+            Se detectaron deadlocks en la base de datos {{ $labels.datname }}.
+            Indica transacciones concurrentes con conflictos de lock.
+
+      # Lag de replicación — más de 30 segundos de retraso
+      - alert: PostgresReplicationLag
+        expr: >
+          pg_replication_lag > 30
+        for: 2m
+        labels:
+          severity: critical
+          source_type: database
+        annotations:
+          summary: >-
+            Replication lag: {{ printf "%.0f" $value }}s
+          description: >-
+            La réplica lleva 2 minutos con {{ printf "%.0f" $value }} segundos de lag
+            respecto al primario. Riesgo de pérdida de datos si falla el primario.
+
+      # Cache hit ratio bajo — menos del 90% de lecturas servidas desde cache
+      - alert: PostgresLowCacheHitRatio
+        expr: >
+          (
+            sum by (datname, instance) (
+              rate(pg_stat_database_blks_hit{datname!="", datname!="template0", datname!="template1"}[5m])
+            )
+            /
+            (
+              sum by (datname, instance) (
+                rate(pg_stat_database_blks_hit{datname!="", datname!="template0", datname!="template1"}[5m])
+              )
+              +
+              sum by (datname, instance) (
+                rate(pg_stat_database_blks_read{datname!="", datname!="template0", datname!="template1"}[5m])
+              )
+            )
+          ) * 100 < 90
+        for: 5m
+        labels:
+          severity: medium
+          source_type: database
+        annotations:
+          summary: >-
+            Cache hit ratio {{ printf "%.1f" $value }}%: {{ $labels.datname }}
+          description: >-
+            La base de datos {{ $labels.datname }} lleva 5 minutos con solo
+            el {{ printf "%.1f" $value }}% de lecturas desde cache.
+            Puede indicar queries pesadas o shared_buffers insuficiente.
+
+      # Crecimiento acelerado — la BD crece más de 100MB en 1 hora
+      - alert: PostgresDatabaseSizeGrowth
+        expr: >
+          rate(pg_database_size_bytes{datname!="", datname!="template0", datname!="template1"}[1h])
+          / 1048576 > 100
+        for: 0m
+        labels:
+          severity: medium
+          source_type: database
+        annotations:
+          summary: >-
+            Crecimiento rápido ({{ printf "%.1f" $value }} MB/h): {{ $labels.datname }}
+          description: >-
+            La base de datos {{ $labels.datname }} está creciendo más de 100MB/hora.
+            Posible insert masivo, falta de vacuums o acumulación de dead tuples.

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -25,3 +25,9 @@ scrape_configs:
   - job_name: "docker"
     static_configs:
       - targets: ["host.docker.internal:9323"]
+
+  # Métricas de PostgreSQL vía postgres-exporter
+  - job_name: "postgres"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+    metrics_path: /metrics


### PR DESCRIPTION
- PostgresAgent with bounded ReAct loop (max 4 tool calls): tools: pg_stat_activity, pg_stat_database, pg_stat_replication, pg_locks matches() routes by source_type='database' or target 'postgres/*'
- 6 runbooks seeded in ChromaDB collection 'runbooks-postgres': connection_exhaustion, long_running_transaction, deadlock, replication_lag, low_cache_hit, database_growth
- 6 Prometheus alert rules in postgres_alerts group (15s interval): PostgresConnectionsExhausted, PostgresLongRunningTransaction, PostgresDeadLocks, PostgresReplicationLag, PostgresLowCacheHitRatio, PostgresDatabaseSizeGrowth
- docker-compose: postgres-demo (port 5433) + postgres-exporter (9187)
- prometheus.yml: scrape job 'postgres' targeting postgres-exporter
- alert_processor: builds target 'postgres/<datname>' for DB alerts
- DockerAgent.matches(): explicitly excludes source_type='database'
- requirements.txt: add psycopg2-binary>=2.9.0
- langgraph_engine: fix Python 3.9 — Optional[dict] instead of dict|None
- Tested end-to-end: real deadlock -> Prometheus -> Alertmanager ->
  backend -> PostgresAgent -> analysis saved in Supabase