### PR TITLE
feat(Sprint 2): US-06b/07/08b/09/10/HU-11/12/13 + Podman + PostgreSQL full support

### DIFF
--- a/.env.podman
+++ b/.env.podman
@@ -1,0 +1,5 @@
+# Podman-specific environment overrides.
+# Loaded automatically by podman.sh — do NOT commit secrets here.
+
+# Socket path inside the Podman VM (UID 501 = core user in podman-machine-default)
+DOCKER_SOCKET=/run/user/501/podman/podman.sock

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -2,10 +2,27 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Instalar dependencias del sistema para compilar paquetes nativos
+# Dependencias del sistema:
+# - build-essential: compilar wheels nativos
+# - curl/ca-certificates: para descargar Docker CLI estático
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Docker CLI (estático) para que /api/execute-action pueda correr:
+#   docker restart <container>
+#   docker logs <container>
+#
+# Evita depender del paquete `docker.io` (no siempre disponible/igual en slim).
+ARG DOCKER_CLI_VERSION=27.0.3
+RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz" \
+    -o /tmp/docker.tgz \
+  && tar -xzf /tmp/docker.tgz -C /tmp \
+  && mv /tmp/docker/docker /usr/local/bin/docker \
+  && chmod +x /usr/local/bin/docker \
+  && rm -rf /tmp/docker /tmp/docker.tgz
 
 # Copiar e instalar dependencias Python
 COPY requirements.txt .

--- a/Backend/db/migrations/002_incident_action_flow.sql
+++ b/Backend/db/migrations/002_incident_action_flow.sql
@@ -1,0 +1,6 @@
+-- Agrega soporte para aprobacion y ejecucion controlada de soluciones en incidentes.
+ALTER TABLE incidents
+  ADD COLUMN IF NOT EXISTS proposed_action TEXT,
+  ADD COLUMN IF NOT EXISTS action_result TEXT,
+  ADD COLUMN IF NOT EXISTS action_error TEXT,
+  ADD COLUMN IF NOT EXISTS executed_at TIMESTAMPTZ;

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -11,7 +11,14 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    # Dev note: the Vite dev server can be accessed as localhost, 127.0.0.1,
+    # or a LAN IP (e.g. http://192.168.x.x:5173). If CORS doesn't include the
+    # exact origin, browsers surface it as "TypeError: Failed to fetch".
+    allow_origins=[
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ],
+    allow_origin_regex=r"^http://(\d{1,3}\.){3}\d{1,3}:5173$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routers import alerts, incidents
+from routers import actions, alerts, incidents
 
 app = FastAPI(
     title="Sentinel-SoftServe API",
@@ -19,6 +19,7 @@ app.add_middleware(
 
 app.include_router(incidents.router)
 app.include_router(alerts.router)
+app.include_router(actions.router)
 
 
 @app.get("/")

--- a/Backend/models/incident.py
+++ b/Backend/models/incident.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel
 
 SourceType   = Literal["container", "database", "manual"]
-RuntimeType  = Literal["docker", "kubernetes"]
+RuntimeType  = Literal["docker", "podman", "kubernetes"]
 SeverityType = Literal["critical", "high", "medium", "low"]
 StatusType   = Literal[
     "detected",

--- a/Backend/models/incident.py
+++ b/Backend/models/incident.py
@@ -12,6 +12,7 @@ StatusType   = Literal[
     "analyzed",
     "awaiting_approval",
     "executing_solution",
+    "verifying",
     "resolved",
     "failed",
 ]

--- a/Backend/models/incident.py
+++ b/Backend/models/incident.py
@@ -6,7 +6,15 @@ from pydantic import BaseModel
 SourceType   = Literal["container", "database", "manual"]
 RuntimeType  = Literal["docker", "kubernetes"]
 SeverityType = Literal["critical", "high", "medium", "low"]
-StatusType   = Literal["detected", "investigating", "analyzed", "resolved"]
+StatusType   = Literal[
+    "detected",
+    "investigating",
+    "analyzed",
+    "awaiting_approval",
+    "executing_solution",
+    "resolved",
+    "failed",
+]
 
 
 class IncidentCreate(BaseModel):
@@ -37,6 +45,10 @@ class IncidentResponse(BaseModel):
     server_name:       Optional[str] = None
     incident_type:     Optional[str] = None
     agent_reasoning:   Optional[str] = None
+    proposed_action:   Optional[str] = None
+    action_result:     Optional[str] = None
+    action_error:      Optional[str] = None
+    executed_at:       Optional[datetime] = None
     resolved_at:       Optional[datetime] = None
     metrics_snapshot:  Optional[dict] = None
     created_at:        datetime

--- a/Backend/routers/actions.py
+++ b/Backend/routers/actions.py
@@ -5,6 +5,7 @@ import re
 import shlex
 import subprocess
 from datetime import datetime, timezone
+from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -35,7 +36,7 @@ class ExecuteActionResponse(BaseModel):
     exit_code: int
     stdout: str
     stderr: str
-    friendly_message: str | None = None
+    friendly_message: Optional[str] = None
 
 
 # ── Validadores ───────────────────────────────────────────────────────────────

--- a/Backend/routers/actions.py
+++ b/Backend/routers/actions.py
@@ -156,3 +156,57 @@ async def execute_action(body: ExecuteActionRequest, user=Depends(get_current_us
             else "La ejecución automática falló. Se recomienda revisión manual."
         ),
     )
+
+
+class ActionDecisionRequest(BaseModel):
+    comment: str = Field(default="", max_length=500)
+
+
+def _get_awaiting_incident(incident_id: str):
+    response = (
+        supabase.table("incidents")
+        .select("id,status")
+        .eq("id", incident_id)
+        .single()
+        .execute()
+    )
+    incident = response.data
+    if not incident:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
+    if incident.get("status") != "awaiting_approval":
+        raise HTTPException(
+            status_code=409,
+            detail="El incidente no está en estado 'Esperando aprobación'",
+        )
+    return incident
+
+
+@router.post("/incidents/{incident_id}/reject")
+async def reject_action(
+    incident_id: str,
+    body: ActionDecisionRequest,
+    user=Depends(get_current_user),
+):
+    _get_awaiting_incident(incident_id)
+    note = body.comment.strip() or "Acción rechazada por el ingeniero."
+    supabase.table("incidents").update({
+        "status": "failed",
+        "action_error": f"[RECHAZADO] {note}",
+        "executed_at": datetime.now(tz=timezone.utc).isoformat(),
+    }).eq("id", incident_id).execute()
+    return {"incident_id": incident_id, "status": "failed", "note": note}
+
+
+@router.post("/incidents/{incident_id}/postpone")
+async def postpone_action(
+    incident_id: str,
+    body: ActionDecisionRequest,
+    user=Depends(get_current_user),
+):
+    _get_awaiting_incident(incident_id)
+    note = body.comment.strip() or "Acción pospuesta por el ingeniero."
+    supabase.table("incidents").update({
+        "status": "analyzed",
+        "action_error": f"[POSPUESTO] {note}",
+    }).eq("id", incident_id).execute()
+    return {"incident_id": incident_id, "status": "analyzed", "note": note}

--- a/Backend/routers/actions.py
+++ b/Backend/routers/actions.py
@@ -1,0 +1,158 @@
+import re
+import shlex
+import subprocess
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from auth import get_current_user
+from db.supabase_client import supabase
+
+router = APIRouter(prefix="/api", tags=["actions"])
+
+_CONTAINER_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+
+
+class ExecuteActionRequest(BaseModel):
+    incident_id: str = Field(..., min_length=1)
+    command: str = Field(..., min_length=1, max_length=200)
+
+
+class ExecuteActionResponse(BaseModel):
+    incident_id: str
+    status: str
+    exit_code: int
+    stdout: str
+    stderr: str
+    friendly_message: str | None = None
+
+
+def _validate_and_parse_command(command: str) -> list[str]:
+    """
+    Acepta unicamente:
+      - docker restart <container>
+      - docker logs <container>
+    """
+    try:
+        tokens = shlex.split(command.strip())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Comando invalido: {exc}")
+
+    if len(tokens) != 3:
+        raise HTTPException(status_code=400, detail="Formato de comando no permitido")
+
+    if tokens[0] != "docker" or tokens[1] not in {"restart", "logs"}:
+        raise HTTPException(status_code=400, detail="Comando no permitido")
+
+    container = tokens[2]
+    if not _CONTAINER_NAME_RE.match(container):
+        raise HTTPException(status_code=400, detail="Nombre de contenedor invalido")
+
+    return tokens
+
+
+@router.post("/execute-action", response_model=ExecuteActionResponse)
+async def execute_action(body: ExecuteActionRequest, user=Depends(get_current_user)):
+    incident_response = (
+        supabase.table("incidents")
+        .select("id,status,proposed_action")
+        .eq("id", body.incident_id)
+        .single()
+        .execute()
+    )
+
+    incident = incident_response.data
+    if not incident:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
+
+    if incident.get("status") != "awaiting_approval":
+        raise HTTPException(
+            status_code=409,
+            detail="El incidente no esta en estado 'Esperando aprobacion'",
+        )
+
+    proposed_action = (incident.get("proposed_action") or "").strip()
+    requested_command = body.command.strip()
+
+    if not proposed_action:
+        raise HTTPException(status_code=400, detail="El incidente no tiene accion propuesta")
+
+    if requested_command != proposed_action:
+        raise HTTPException(
+            status_code=400,
+            detail="El comando no coincide con la accion propuesta del incidente",
+        )
+
+    command_tokens = _validate_and_parse_command(requested_command)
+
+    supabase.table("incidents").update({"status": "executing_solution"}).eq("id", body.incident_id).execute()
+
+    executed_at = datetime.now(tz=timezone.utc).isoformat()
+    try:
+        completed = subprocess.run(
+            command_tokens,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except FileNotFoundError:
+        stderr = "El runtime no tiene disponible el binario 'docker'"
+        supabase.table("incidents").update({
+            "status": "failed",
+            "action_result": "",
+            "action_error": stderr,
+            "executed_at": executed_at,
+        }).eq("id", body.incident_id).execute()
+
+        return ExecuteActionResponse(
+            incident_id=body.incident_id,
+            status="failed",
+            exit_code=127,
+            stdout="",
+            stderr=stderr,
+            friendly_message="La ejecución automática falló. Se recomienda revisión manual.",
+        )
+    except subprocess.TimeoutExpired as exc:
+        stderr = (exc.stderr or "").strip() or "Timeout al ejecutar el comando"
+        stdout = (exc.stdout or "").strip()
+        supabase.table("incidents").update({
+            "status": "failed",
+            "action_result": stdout,
+            "action_error": stderr,
+            "executed_at": executed_at,
+        }).eq("id", body.incident_id).execute()
+
+        return ExecuteActionResponse(
+            incident_id=body.incident_id,
+            status="failed",
+            exit_code=124,
+            stdout=stdout,
+            stderr=stderr,
+            friendly_message="La ejecución automática falló. Se recomienda revisión manual.",
+        )
+
+    stdout = (completed.stdout or "").strip()
+    stderr = (completed.stderr or "").strip()
+    status = "resolved" if completed.returncode == 0 else "failed"
+
+    supabase.table("incidents").update({
+        "status": status,
+        "action_result": stdout,
+        "action_error": stderr,
+        "executed_at": executed_at,
+    }).eq("id", body.incident_id).execute()
+
+    return ExecuteActionResponse(
+        incident_id=body.incident_id,
+        status=status,
+        exit_code=completed.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        friendly_message=(
+            None
+            if status == "resolved"
+            else "La ejecución automática falló. Se recomienda revisión manual."
+        ),
+    )

--- a/Backend/routers/actions.py
+++ b/Backend/routers/actions.py
@@ -3,11 +3,12 @@ import shlex
 import subprocess
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from auth import get_current_user
 from db.supabase_client import supabase
+from services.verification import verify_resolution
 
 router = APIRouter(prefix="/api", tags=["actions"])
 
@@ -53,10 +54,14 @@ def _validate_and_parse_command(command: str) -> list[str]:
 
 
 @router.post("/execute-action", response_model=ExecuteActionResponse)
-async def execute_action(body: ExecuteActionRequest, user=Depends(get_current_user)):
+async def execute_action(
+    body: ExecuteActionRequest,
+    background_tasks: BackgroundTasks,
+    user=Depends(get_current_user),
+):
     incident_response = (
         supabase.table("incidents")
-        .select("id,status,proposed_action")
+        .select("id,status,proposed_action,target,agent_reasoning,container_runtime")
         .eq("id", body.incident_id)
         .single()
         .execute()
@@ -135,10 +140,37 @@ async def execute_action(body: ExecuteActionRequest, user=Depends(get_current_us
 
     stdout = (completed.stdout or "").strip()
     stderr = (completed.stderr or "").strip()
-    status = "resolved" if completed.returncode == 0 else "failed"
 
+    if completed.returncode == 0:
+        # Comando exitoso → pasamos a 'verifying' mientras el agente verifica salud
+        supabase.table("incidents").update({
+            "status": "verifying",
+            "action_result": stdout,
+            "action_error": stderr,
+            "executed_at": executed_at,
+        }).eq("id", body.incident_id).execute()
+
+        current_reasoning = (incident.get("agent_reasoning") or "").strip()
+        container_runtime = (incident.get("container_runtime") or "docker").lower()
+        background_tasks.add_task(
+            verify_resolution,
+            body.incident_id,
+            incident["target"] if "target" in incident else command_tokens[2],
+            container_runtime,
+            current_reasoning,
+        )
+
+        return ExecuteActionResponse(
+            incident_id=body.incident_id,
+            status="verifying",
+            exit_code=completed.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    # Comando fallido → failed inmediato
     supabase.table("incidents").update({
-        "status": status,
+        "status": "failed",
         "action_result": stdout,
         "action_error": stderr,
         "executed_at": executed_at,
@@ -146,15 +178,11 @@ async def execute_action(body: ExecuteActionRequest, user=Depends(get_current_us
 
     return ExecuteActionResponse(
         incident_id=body.incident_id,
-        status=status,
+        status="failed",
         exit_code=completed.returncode,
         stdout=stdout,
         stderr=stderr,
-        friendly_message=(
-            None
-            if status == "resolved"
-            else "La ejecución automática falló. Se recomienda revisión manual."
-        ),
+        friendly_message="La ejecución automática falló. Se recomienda revisión manual.",
     )
 
 

--- a/Backend/routers/actions.py
+++ b/Backend/routers/actions.py
@@ -1,3 +1,6 @@
+import json
+import logging
+import os
 import re
 import shlex
 import subprocess
@@ -12,7 +15,13 @@ from services.verification import verify_resolution
 
 router = APIRouter(prefix="/api", tags=["actions"])
 
+logger = logging.getLogger(__name__)
+
 _CONTAINER_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+_PG_DATNAME_RE     = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$")
+
+_PG_ALLOWED_FUNCS    = {"pg_stat_activity", "pg_cancel_backend", "pg_terminate_backend"}
+_PODMAN_ALLOWED_CMDS = {"restart", "logs"}
 
 
 class ExecuteActionRequest(BaseModel):
@@ -29,11 +38,15 @@ class ExecuteActionResponse(BaseModel):
     friendly_message: str | None = None
 
 
-def _validate_and_parse_command(command: str) -> list[str]:
+# ── Validadores ───────────────────────────────────────────────────────────────
+
+def _validate_container_command(command: str) -> list[str]:
     """
     Acepta unicamente:
       - docker restart <container>
       - docker logs <container>
+      - podman restart <container>
+      - podman logs <container>
     """
     try:
         tokens = shlex.split(command.strip())
@@ -43,15 +56,130 @@ def _validate_and_parse_command(command: str) -> list[str]:
     if len(tokens) != 3:
         raise HTTPException(status_code=400, detail="Formato de comando no permitido")
 
-    if tokens[0] != "docker" or tokens[1] not in {"restart", "logs"}:
+    runtime_bin, subcommand, container = tokens
+
+    if runtime_bin not in {"docker", "podman"}:
         raise HTTPException(status_code=400, detail="Comando no permitido")
 
-    container = tokens[2]
+    allowed_cmds = {"restart", "logs"}
+    if subcommand not in allowed_cmds:
+        raise HTTPException(status_code=400, detail=f"Subcomando '{subcommand}' no permitido")
+
     if not _CONTAINER_NAME_RE.match(container):
         raise HTTPException(status_code=400, detail="Nombre de contenedor invalido")
 
     return tokens
 
+
+def _validate_pg_command(command: str) -> tuple[str, str]:
+    """
+    Acepta unicamente:
+      - pg_stat_activity <datname>      (solo lectura — observación)
+      - pg_cancel_backend <datname>     (cancela query activa, conexión sigue viva)
+      - pg_terminate_backend <datname>  (termina todas las conexiones de la BD)
+    Retorna (funcion, datname).
+    """
+    tokens = command.strip().split()
+    if len(tokens) != 2:
+        raise HTTPException(status_code=400, detail="Formato de comando Postgres no permitido")
+
+    func, datname = tokens
+    if func not in _PG_ALLOWED_FUNCS:
+        raise HTTPException(status_code=400, detail=f"Función Postgres no permitida: '{func}'")
+    if not _PG_DATNAME_RE.match(datname):
+        raise HTTPException(status_code=400, detail="Nombre de base de datos inválido")
+
+    return func, datname
+
+
+# ── Ejecutores ────────────────────────────────────────────────────────────────
+
+def _run_pg_command(func: str, datname: str) -> tuple[int, str, str]:
+    """
+    Ejecuta la función Postgres segura contra la BD indicada.
+    Retorna (exit_code, stdout_json, stderr).
+    - pg_stat_activity     → SELECT de pg_stat_activity (lectura)
+    - pg_cancel_backend    → pg_cancel_backend() sobre queries activas
+    - pg_terminate_backend → pg_terminate_backend() sobre todas las conexiones
+    """
+    try:
+        import psycopg2          # type: ignore
+        import psycopg2.extras   # type: ignore
+    except ImportError:
+        return 1, "", "psycopg2 no está instalado en el backend"
+
+    dsn = os.getenv("POSTGRES_DSN")
+    if not dsn:
+        host     = os.getenv("POSTGRES_HOST", "localhost")
+        port     = os.getenv("POSTGRES_PORT", "5432")
+        user     = os.getenv("POSTGRES_USER", "sentinel")
+        password = os.getenv("POSTGRES_PASSWORD", "")
+        db       = os.getenv("POSTGRES_DB", "sentinel_demo")
+        dsn = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+    try:
+        conn = psycopg2.connect(dsn, connect_timeout=10)
+        conn.autocommit = True
+    except Exception as e:
+        return 1, "", f"No se pudo conectar a PostgreSQL: {e}"
+
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            if func == "pg_stat_activity":
+                cur.execute("""
+                    SELECT pid, usename, state, wait_event_type, wait_event,
+                           EXTRACT(EPOCH FROM (now() - query_start))::int AS duracion_s,
+                           LEFT(query, 200) AS query
+                    FROM pg_stat_activity
+                    WHERE datname = %s AND pid <> pg_backend_pid()
+                    ORDER BY duracion_s DESC NULLS LAST
+                    LIMIT 20
+                """, (datname,))
+                rows = [dict(r) for r in cur.fetchall()]
+                stdout = json.dumps({"datname": datname, "conexiones": rows}, indent=2, default=str)
+
+            elif func == "pg_cancel_backend":
+                cur.execute("""
+                    SELECT pid, pg_cancel_backend(pid) AS cancelado,
+                           LEFT(query, 100) AS query
+                    FROM pg_stat_activity
+                    WHERE datname = %s
+                      AND state = 'active'
+                      AND pid <> pg_backend_pid()
+                """, (datname,))
+                rows = [dict(r) for r in cur.fetchall()]
+                stdout = json.dumps({
+                    "datname": datname,
+                    "queries_canceladas": len([r for r in rows if r.get("cancelado")]),
+                    "detalle": rows,
+                }, indent=2, default=str)
+
+            elif func == "pg_terminate_backend":
+                cur.execute("""
+                    SELECT pid, pg_terminate_backend(pid) AS terminado,
+                           usename, state, LEFT(query, 100) AS query
+                    FROM pg_stat_activity
+                    WHERE datname = %s AND pid <> pg_backend_pid()
+                """, (datname,))
+                rows = [dict(r) for r in cur.fetchall()]
+                stdout = json.dumps({
+                    "datname": datname,
+                    "conexiones_terminadas": len([r for r in rows if r.get("terminado")]),
+                    "detalle": rows,
+                }, indent=2, default=str)
+
+            else:
+                stdout = ""
+
+        return 0, stdout, ""
+
+    except Exception as e:
+        return 1, "", f"Error ejecutando {func}: {e}"
+    finally:
+        conn.close()
+
+
+# ── Endpoint principal ────────────────────────────────────────────────────────
 
 @router.post("/execute-action", response_model=ExecuteActionResponse)
 async def execute_action(
@@ -61,7 +189,7 @@ async def execute_action(
 ):
     incident_response = (
         supabase.table("incidents")
-        .select("id,status,proposed_action,target,agent_reasoning,container_runtime")
+        .select("id,status,proposed_action,target,source_type,agent_reasoning,container_runtime")
         .eq("id", body.incident_id)
         .single()
         .execute()
@@ -89,11 +217,62 @@ async def execute_action(
             detail="El comando no coincide con la accion propuesta del incidente",
         )
 
-    command_tokens = _validate_and_parse_command(requested_command)
+    source_type = (incident.get("source_type") or "container").lower()
+    is_postgres  = requested_command.split()[0] in _PG_ALLOWED_FUNCS or source_type == "database"
 
     supabase.table("incidents").update({"status": "executing_solution"}).eq("id", body.incident_id).execute()
-
     executed_at = datetime.now(tz=timezone.utc).isoformat()
+
+    # ── Rama Postgres ─────────────────────────────────────────────────────────
+    if is_postgres:
+        func, datname = _validate_pg_command(requested_command)
+        logger.info(f"[actions] Ejecutando Postgres: {func}({datname})")
+        exit_code, stdout, stderr = _run_pg_command(func, datname)
+
+        if exit_code == 0:
+            supabase.table("incidents").update({
+                "status": "verifying",
+                "action_result": stdout,
+                "action_error": stderr or None,
+                "executed_at": executed_at,
+            }).eq("id", body.incident_id).execute()
+
+            current_reasoning = (incident.get("agent_reasoning") or "").strip()
+            background_tasks.add_task(
+                verify_resolution,
+                body.incident_id,
+                incident.get("target", f"postgres/{datname}"),
+                "postgres",
+                current_reasoning,
+            )
+
+            return ExecuteActionResponse(
+                incident_id=body.incident_id,
+                status="verifying",
+                exit_code=0,
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        supabase.table("incidents").update({
+            "status": "failed",
+            "action_result": stdout,
+            "action_error": stderr,
+            "executed_at": executed_at,
+        }).eq("id", body.incident_id).execute()
+
+        return ExecuteActionResponse(
+            incident_id=body.incident_id,
+            status="failed",
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            friendly_message="La ejecución Postgres falló. Revisa los logs del backend.",
+        )
+
+    # ── Rama Docker / Podman ─────────────────────────────────────────────────
+    command_tokens = _validate_container_command(requested_command)
+
     try:
         completed = subprocess.run(
             command_tokens,
@@ -142,7 +321,6 @@ async def execute_action(
     stderr = (completed.stderr or "").strip()
 
     if completed.returncode == 0:
-        # Comando exitoso → pasamos a 'verifying' mientras el agente verifica salud
         supabase.table("incidents").update({
             "status": "verifying",
             "action_result": stdout,
@@ -151,7 +329,9 @@ async def execute_action(
         }).eq("id", body.incident_id).execute()
 
         current_reasoning = (incident.get("agent_reasoning") or "").strip()
-        container_runtime = (incident.get("container_runtime") or "docker").lower()
+        # Preferir el runtime del binario ejecutado (docker/podman) sobre el campo del incidente
+        # para que verify_resolution sepa qué socket usar.
+        container_runtime = command_tokens[0]  # "docker" o "podman"
         background_tasks.add_task(
             verify_resolution,
             body.incident_id,

--- a/Backend/routers/alerts.py
+++ b/Backend/routers/alerts.py
@@ -44,6 +44,12 @@ async def receive_alertmanager_webhook(
         result = process_prometheus_alert(alert.model_dump())
         if result:
             incident_id, target, logs, severity, title, container_runtime = result
+            labels: dict = {}
+            if container_runtime:
+                labels["container_runtime"] = container_runtime
+            # Propagar source_type para que el supervisor pueda proponer acciones correctas
+            source_type = alert.labels.get("source_type", "container")
+            labels["source_type"] = source_type
             background_tasks.add_task(
                 run_langgraph_engine,
                 incident_id,
@@ -51,7 +57,7 @@ async def receive_alertmanager_webhook(
                 logs,
                 severity,
                 title,
-                labels={"container_runtime": container_runtime} if container_runtime else {},
+                labels=labels,
             )
 
     return {"message": "Alertas procesadas", "count": len(webhook.alerts)}

--- a/Backend/routers/incidents.py
+++ b/Backend/routers/incidents.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field
 from auth import get_current_user
 from db.supabase_client import supabase
 from models.incident import IncidentStatusUpdate
+from services.agents.memory.incidents import query_incidents
+from services.agents.memory.runbooks import query_runbooks
 from services.langgraph_engine import run_langgraph_engine
 
 router = APIRouter(prefix="/api/incidents", tags=["incidents"])
@@ -101,3 +103,66 @@ async def create_incident(
     )
 
     return created_incident
+
+
+def _runbook_collection(source_type: str) -> str:
+    return "runbooks-postgres" if source_type == "database" else "runbooks-docker"
+
+
+def _incidents_collection(source_type: str) -> str:
+    return "incidents-postgres" if source_type == "database" else "incidents-docker"
+
+
+def _parse_runbook_title(text: str) -> str:
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("RUNBOOK:"):
+            return line.replace("RUNBOOK:", "").strip()
+    return "Runbook"
+
+
+@router.get("/{incident_id}/runbooks")
+async def get_incident_runbooks(
+    incident_id: str,
+    q: Optional[str] = None,
+    user=Depends(get_current_user),
+):
+    response = (
+        supabase.table("incidents")
+        .select("source_type,incident_type,title")
+        .eq("id", incident_id)
+        .single()
+        .execute()
+    )
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
+
+    incident = response.data
+    collection = _runbook_collection(incident.get("source_type") or "container")
+    query = q or f"{incident.get('incident_type') or 'unknown'} {incident.get('title') or ''}"
+
+    texts = query_runbooks(collection, query.strip(), k=5)
+    return [{"title": _parse_runbook_title(t), "content": t} for t in texts]
+
+
+@router.get("/{incident_id}/similar")
+async def get_similar_incidents(
+    incident_id: str,
+    user=Depends(get_current_user),
+):
+    response = (
+        supabase.table("incidents")
+        .select("source_type,incident_type,title,severity")
+        .eq("id", incident_id)
+        .single()
+        .execute()
+    )
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
+
+    incident = response.data
+    collection = _incidents_collection(incident.get("source_type") or "container")
+    query = f"{incident.get('incident_type') or 'unknown'} {incident.get('title') or ''}"
+
+    results = query_incidents(collection, query.strip(), k=6)
+    return [r for r in results if r["id"] != incident_id]

--- a/Backend/routers/incidents.py
+++ b/Backend/routers/incidents.py
@@ -9,6 +9,7 @@ from models.incident import IncidentStatusUpdate
 from services.agents.memory.incidents import query_incidents
 from services.agents.memory.runbooks import query_runbooks
 from services.langgraph_engine import run_langgraph_engine
+from services.prometheus import get_container_metrics, get_postgres_metrics
 
 router = APIRouter(prefix="/api/incidents", tags=["incidents"])
 
@@ -166,3 +167,31 @@ async def get_similar_incidents(
 
     results = query_incidents(collection, query.strip(), k=6)
     return [r for r in results if r["id"] != incident_id]
+
+
+@router.get("/{incident_id}/metrics")
+async def get_incident_metrics(incident_id: str, user=Depends(get_current_user)):
+    response = (
+        supabase.table("incidents")
+        .select("target,source_type,metrics_snapshot")
+        .eq("id", incident_id)
+        .single()
+        .execute()
+    )
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
+
+    incident    = response.data
+    target      = (incident.get("target") or "").strip()
+    source_type = (incident.get("source_type") or "container").lower()
+
+    try:
+        if source_type == "database":
+            datname = target.replace("postgres/", "")
+            return get_postgres_metrics(datname)
+        return get_container_metrics(target)
+    except Exception as exc:
+        snapshot = incident.get("metrics_snapshot")
+        if snapshot:
+            return snapshot
+        raise HTTPException(status_code=503, detail=f"Métricas no disponibles: {exc}")

--- a/Backend/routers/incidents.py
+++ b/Backend/routers/incidents.py
@@ -36,13 +36,16 @@ async def list_incidents(
 
 @router.get("/{incident_id}")
 async def get_incident(incident_id: str, user=Depends(get_current_user)):
-    response = (
-        supabase.table("incidents")
-        .select("*")
-        .eq("id", incident_id)
-        .single()
-        .execute()
-    )
+    try:
+        response = (
+            supabase.table("incidents")
+            .select("*")
+            .eq("id", incident_id)
+            .single()
+            .execute()
+        )
+    except Exception:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
     if not response.data:
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
     return response.data
@@ -128,13 +131,16 @@ async def get_incident_runbooks(
     q: Optional[str] = None,
     user=Depends(get_current_user),
 ):
-    response = (
-        supabase.table("incidents")
-        .select("source_type,incident_type,title")
-        .eq("id", incident_id)
-        .single()
-        .execute()
-    )
+    try:
+        response = (
+            supabase.table("incidents")
+            .select("source_type,incident_type,title")
+            .eq("id", incident_id)
+            .single()
+            .execute()
+        )
+    except Exception:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
     if not response.data:
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
 
@@ -151,13 +157,16 @@ async def get_similar_incidents(
     incident_id: str,
     user=Depends(get_current_user),
 ):
-    response = (
-        supabase.table("incidents")
-        .select("source_type,incident_type,title,severity")
-        .eq("id", incident_id)
-        .single()
-        .execute()
-    )
+    try:
+        response = (
+            supabase.table("incidents")
+            .select("source_type,incident_type,title,severity")
+            .eq("id", incident_id)
+            .single()
+            .execute()
+        )
+    except Exception:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
     if not response.data:
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
 
@@ -171,13 +180,16 @@ async def get_similar_incidents(
 
 @router.get("/{incident_id}/metrics")
 async def get_incident_metrics(incident_id: str, user=Depends(get_current_user)):
-    response = (
-        supabase.table("incidents")
-        .select("target,source_type,metrics_snapshot")
-        .eq("id", incident_id)
-        .single()
-        .execute()
-    )
+    try:
+        response = (
+            supabase.table("incidents")
+            .select("target,source_type,metrics_snapshot")
+            .eq("id", incident_id)
+            .single()
+            .execute()
+        )
+    except Exception:
+        raise HTTPException(status_code=404, detail="Incidente no encontrado")
     if not response.data:
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
 

--- a/Backend/scripts/seed_podman_runbooks.py
+++ b/Backend/scripts/seed_podman_runbooks.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+Seed de runbooks para el PodmanAgent en ChromaDB.
+
+Ejecutar desde el directorio Backend/:
+    python scripts/seed_podman_runbooks.py
+
+Carga los runbooks en la colección 'runbooks-podman'.
+Si la colección ya tenía datos previos, los elimina y recarga desde cero.
+"""
+
+import os
+import sys
+from urllib.parse import urlparse
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env"))
+
+import chromadb
+
+CHROMA_HOST = os.getenv("CHROMA_HOST", "http://localhost:8001")
+COLLECTION_NAME = "runbooks-podman"
+
+RUNBOOKS = [
+    {
+        "id": "podman-runbook-crash-001",
+        "type": "app_crash",
+        "text": """RUNBOOK: Contenedor caído — PodmanContainerCrashed
+
+TIPO: app_crash
+
+SEÑALES:
+- podman_container_state == 4 (exited) de forma inesperada
+- Estado del contenedor: exited con exit code distinto de 0
+- El servicio deja de responder en su puerto
+
+DIAGNÓSTICO:
+En Podman rootless el contenedor es un proceso hijo directo del usuario (no hay daemon).
+Si el proceso padre muere (logout de sesión, reboot) los contenedores mueren con él.
+Otras causas frecuentes:
+- La aplicación lanzó una excepción no capturada y salió (exit code 1)
+- Error de configuración al arrancar (variables de entorno faltantes, fichero config ausente)
+- El proceso fue terminado por señal (SIGKILL, SIGTERM de un script externo)
+- OOM Kill del kernel (verificar con podman inspect —> OOMKilled: true)
+
+DIFERENCIAS PODMAN vs DOCKER:
+- No hay restart automático a menos que se configure --restart=always en el pod/contenedor
+- En rootless, el socket está en /run/user/<uid>/podman/podman.sock
+- Systemd units son la forma canónica de gestionar reinicios en Podman rootless
+
+ACCIONES RECOMENDADAS:
+1. Ver el estado y exit code del contenedor:
+   podman inspect <nombre> --format "{{.State.ExitCode}} {{.State.Error}}"
+2. Ver los últimos logs antes del crash:
+   podman logs --tail 100 <nombre>
+3. Reiniciar el contenedor:
+   podman start <nombre>
+4. Si el reinicio falla, ver qué ocurre en tiempo real:
+   podman start <nombre> && podman logs -f <nombre>
+5. Si es rootless y se cayó por logout: activar linger para que los contenedores
+   persistan sin sesión activa:
+   loginctl enable-linger <usuario>
+6. Para reinicio automático, generar una systemd unit:
+   podman generate systemd --name <nombre> --files --new
+
+URGENCIA: ALTA — el servicio está caído""",
+    },
+    {
+        "id": "podman-runbook-oom-001",
+        "type": "oom",
+        "text": """RUNBOOK: OOM Kill — PodmanContainerOOMKilled
+
+TIPO: oom
+
+SEÑALES:
+- increase(podman_container_oom_events_total[5m]) > 0
+- podman inspect muestra OOMKilled: true
+- El contenedor se reinicia con exit code 137 (SIGKILL)
+- Logs muestran: "Killed" o "Out of memory: Kill process"
+
+DIAGNÓSTICO:
+El OOM Killer del kernel termina el proceso cuando el sistema no tiene suficiente
+memoria física + swap. En Podman rootless los límites de memoria son más estrictos
+porque se aplican cgroups v2 por usuario. Causas comunes:
+- Memory limit demasiado bajo para la carga actual de la aplicación
+- Memory leak en la aplicación (memoria crece indefinidamente)
+- Pico de carga inesperado que supera el límite configurado
+- JVM o runtime con heap mal configurado para el límite del contenedor
+
+DIFERENCIAS PODMAN vs DOCKER:
+- Podman usa cgroups v2 por defecto en sistemas modernos (más granular)
+- En rootless, los límites de memoria los gestiona systemd por usuario
+- El OOM killer puede afectar al pod completo si se configura con --oom-kill-disable=false
+
+ACCIONES RECOMENDADAS:
+1. Confirmar que fue OOM:
+   podman inspect <nombre> --format "OOMKilled: {{.State.OOMKilled}}"
+2. Ver el uso de memoria antes del OOM (si el contenedor está vivo brevemente):
+   podman stats <nombre> --no-stream
+3. Aumentar el límite de memoria del contenedor:
+   podman update --memory 512m --memory-swap 512m <nombre>
+   (o recrea el contenedor con --memory aumentado)
+4. Si la aplicación es Java/JVM: configurar -XX:MaxRAMPercentage=75 para que
+   respete el límite del contenedor automáticamente
+5. Revisar si hay memory leak: monitorear uso de memoria con podman stats durante
+   un período de carga normal
+6. Si el límite ya es adecuado: revisar el código de la aplicación buscando leaks
+
+URGENCIA: CRÍTICA — el servicio está caído por falta de memoria""",
+    },
+    {
+        "id": "podman-runbook-high-memory-001",
+        "type": "high_memory",
+        "text": """RUNBOOK: Alta memoria — PodmanContainerHighMemory
+
+TIPO: high_memory
+
+SEÑALES:
+- (podman_container_mem_usage_bytes / podman_container_mem_limit_bytes) * 100 > 85
+- podman stats muestra MEM USAGE/LIMIT > 85%
+- El sistema puede empezar a usar swap si hay disponible
+
+DIAGNÓSTICO:
+Uso de memoria por encima del 85% del límite es señal de OOM inminente.
+En Podman las causas son similares a Docker pero con matices:
+- Caches internas de la aplicación que crecen con el tiempo
+- Muchas conexiones activas sin cerrar
+- JVM con GC que no libera memoria a tiempo
+- Carga de trabajo mayor de la esperada para el límite configurado
+
+ACCIONES RECOMENDADAS:
+1. Ver memoria en tiempo real:
+   podman stats <nombre> --no-stream --format "table {{.Name}} {{.MemUsage}} {{.MemPerc}}"
+2. Si la aplicación tiene API de métricas/actuator: consultar uso interno de heap
+3. Aumentar límite de memoria preventivamente:
+   podman update --memory 1g <nombre>
+4. Forzar GC si es JVM (via JMX o API de administración)
+5. Revisar si hay endpoints con alta carga de datos en memoria
+6. Si el sistema tiene swap disponible y el contenedor no lo usa:
+   podman update --memory-swap -1 <nombre>  # usa swap ilimitado del host
+
+URGENCIA: ALTA — OOM Kill inminente si no se actúa""",
+    },
+    {
+        "id": "podman-runbook-restart-loop-001",
+        "type": "restart_loop",
+        "text": """RUNBOOK: Restart loop — PodmanContainerRestartLoop
+
+TIPO: restart_loop
+
+SEÑALES:
+- changes(podman_container_state[10m]) >= 3
+- podman ps muestra STATUS: Restarting
+- Los logs muestran el mismo error repetidamente al arrancar
+- El exit code es siempre el mismo (típicamente 1, 2 o 127)
+
+DIAGNÓSTICO:
+Un contenedor Podman en restart loop está fallando al arrancar o poco después.
+Diferencia clave con Docker: en Podman rootless el reinicio automático requiere
+que el contenedor tenga --restart=always y que linger esté habilitado para el usuario.
+Causas comunes:
+- Variable de entorno faltante o incorrecta (el proceso sale con código de error)
+- Servicio externo no disponible al arrancar (base de datos, API, etc.)
+- Permisos incorrectos en volúmenes montados (rootless cambia el UID del proceso)
+- Imagen corrupta o incompatible con la arquitectura del host
+- Puerto ya en uso por otro proceso o contenedor
+
+DIFERENCIAS PODMAN vs DOCKER:
+- En rootless, los volúmenes del host pueden tener problemas de UID/GID mapping
+  (el proceso dentro del contenedor corre como UID 0 mapeado a tu UID real)
+- Verificar permisos con: podman unshare ls -la /ruta/en/host
+
+ACCIONES RECOMENDADAS:
+1. Ver cuántas veces reinició y el exit code:
+   podman inspect <nombre> --format "RestartCount={{.RestartCount}} ExitCode={{.State.ExitCode}}"
+2. Ver los logs del último intento (incluye arranques fallidos):
+   podman logs --tail 50 <nombre>
+3. Detener el loop de reinicios para investigar:
+   podman stop <nombre>
+4. Probar arranque interactivo para ver el error en tiempo real:
+   podman run --rm -it --entrypoint /bin/sh <imagen>
+5. Si hay problema de permisos en volúmenes:
+   podman unshare chown -R 0:0 /ruta/del/volumen
+6. Si el servicio externo no está listo: añadir --health-start-period o lógica de retry
+   en la aplicación
+
+URGENCIA: ALTA — el servicio no está disponible""",
+    },
+    {
+        "id": "podman-runbook-config-error-001",
+        "type": "config_error",
+        "text": """RUNBOOK: Error de configuración — PodmanContainerUnhealthy / config_error
+
+TIPO: config_error
+
+SEÑALES:
+- El contenedor arranca pero el servicio no responde
+- Logs muestran: "configuration file not found", "invalid environment variable", "permission denied"
+- podman_container_state == 2 (stopped) sostenido
+- Exit code 1 o 2 (error genérico de la aplicación)
+
+DIAGNÓSTICO:
+Errores de configuración en Podman tienen particularidades respecto a Docker:
+- Variables de entorno: Podman las pasa directamente sin daemon intermedio; errores
+  tipográficos en nombres de variables son comunes
+- Montaje de volúmenes: en rootless, los paths del host se remapean a través de
+  el namespace de usuario; un path que no existe en el host falla silenciosamente
+- Secrets y configs: Podman soporta secrets nativos pero la gestión es diferente
+  a Docker Swarm
+- Red: en rootless la red de pods usa slirp4netns por defecto; ciertos puertos
+  privilegiados (< 1024) requieren configuración adicional
+
+ACCIONES RECOMENDADAS:
+1. Ver variables de entorno activas en el contenedor:
+   podman exec <nombre> env | sort
+2. Verificar que los volúmenes están montados correctamente:
+   podman inspect <nombre> --format "{{json .Mounts}}"
+3. Si hay secrets, verificar que existen:
+   podman secret ls
+4. Ejecutar el contenedor con shell para inspeccionar:
+   podman run --rm -it --env-file .env <imagen> /bin/sh
+5. Si hay problemas de red (puerto en uso):
+   ss -tlnp | grep <puerto>
+6. Para puertos privilegiados en rootless:
+   sysctl net.ipv4.ip_unprivileged_port_start=80
+
+URGENCIA: ALTA — el servicio está caído por mal configuración""",
+    },
+    {
+        "id": "podman-runbook-dependency-001",
+        "type": "dependency_failure",
+        "text": """RUNBOOK: Fallo de dependencia — PodmanContainerCrashed (dependency_failure)
+
+TIPO: dependency_failure
+
+SEÑALES:
+- Logs muestran: "connection refused", "no such host", "timeout", "ECONNREFUSED"
+- El contenedor crashea justo después de intentar conectar a otro servicio
+- Otros contenedores del mismo pod están en estado error
+
+DIAGNÓSTICO:
+En un entorno Podman, las dependencias entre contenedores se gestionan diferente a Docker:
+- Los pods de Podman agrupan contenedores (similar a Kubernetes); si el infracontainer
+  falla, todos los contenedores del pod fallan
+- En rootless, la red entre pods usa slirp4netns: la resolución DNS depende de
+  la configuración de /etc/resolv.conf del host
+- Los healthchecks de dependencia no están integrados nativamente en Podman
+  (no hay depends_on como Docker Compose)
+
+ACCIONES RECOMENDADAS:
+1. Ver el estado de todos los contenedores del pod:
+   podman pod inspect <nombre-pod> --format "{{json .Containers}}"
+2. Verificar conectividad desde dentro del contenedor:
+   podman exec <nombre> curl -s http://<servicio>:<puerto>/health
+3. Ver si el servicio del que depende está corriendo:
+   podman ps --filter name=<servicio-dependencia>
+4. Ver logs del servicio dependencia:
+   podman logs --tail 30 <nombre-servicio-dependencia>
+5. Si el fallo es DNS: verificar resolución desde dentro del contenedor:
+   podman exec <nombre> nslookup <hostname>
+6. Añadir lógica de retry/backoff en la aplicación o un init container que espere
+   a que la dependencia esté lista
+
+URGENCIA: ALTA — el servicio no puede operar sin sus dependencias""",
+    },
+]
+
+
+def seed():
+    parsed = urlparse(CHROMA_HOST)
+    client = chromadb.HttpClient(host=parsed.hostname, port=parsed.port or 8000)
+
+    try:
+        client.delete_collection(COLLECTION_NAME)
+        print(f"Colección '{COLLECTION_NAME}' previa eliminada.")
+    except Exception:
+        pass
+
+    collection = client.create_collection(COLLECTION_NAME)
+
+    collection.add(
+        documents=[r["text"] for r in RUNBOOKS],
+        ids=[r["id"] for r in RUNBOOKS],
+        metadatas=[{"type": r["type"], "domain": "podman"} for r in RUNBOOKS],
+    )
+
+    print(f"✓ {len(RUNBOOKS)} runbooks cargados en '{COLLECTION_NAME}' ({CHROMA_HOST}).")
+    print("  Tipos cargados:", [r["type"] for r in RUNBOOKS])
+
+
+if __name__ == "__main__":
+    seed()

--- a/Backend/services/agents/__init__.py
+++ b/Backend/services/agents/__init__.py
@@ -13,6 +13,7 @@ from services.agents.base import DomainAgent, IncidentContext
 
 # Importa los dominios concretos para que se auto-registren.
 from services.agents.docker import agent as _docker_agent      # noqa: F401
+from services.agents.podman import agent as _podman_agent      # noqa: F401
 from services.agents.postgres import agent as _postgres_agent  # noqa: F401
 from services.agents.registry import get_agent, list_agents, register_agent
 

--- a/Backend/services/agents/docker/agent.py
+++ b/Backend/services/agents/docker/agent.py
@@ -52,7 +52,7 @@ class DockerAgent(DomainAgent):
         runtime = (ctx.labels.get("container_runtime") or "").lower()
         if runtime == "docker":
             return True
-        if runtime in {"kubernetes", "containerd"}:
+        if runtime in {"podman", "kubernetes", "containerd"}:
             return False
 
         # Excluir targets que parecen bases de datos

--- a/Backend/services/agents/docker/agent.py
+++ b/Backend/services/agents/docker/agent.py
@@ -10,6 +10,7 @@ Sustituye al antiguo lab2_investigation: además de consultar runbooks,
 
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from pathlib import Path
 from typing import Callable
 
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 _PROMPT_PATH = Path(__file__).parent / "prompt.md"
 _MAX_TOOL_ITERATIONS = 4  # evita loops infinitos del LLM
+_MEMORY_STAGE_TIMEOUT_SEC = 8
 
 
 class DockerAgent(DomainAgent):
@@ -76,8 +78,8 @@ class DockerAgent(DomainAgent):
 
         # 1. Memoria: runbooks + incidentes pasados similares
         query = f"{ctx.incident_type or ''} {ctx.title} {ctx.logs[:300]}"
-        runbooks = self.recall_runbooks(query, k=3)
-        past_incidents = self.recall_similar_incidents(query, k=3)
+        runbooks = self._safe_recall_runbooks(query, k=3)
+        past_incidents = self._safe_recall_incidents(query, k=3)
 
         # 2. Construye el mensaje de usuario con toda la evidencia
         user_msg = _build_user_message(ctx, runbooks, past_incidents)
@@ -90,6 +92,38 @@ class DockerAgent(DomainAgent):
             tool_calls=tool_calls,
             similar_past_incidents=past_incidents,
         )
+
+    def _safe_recall_runbooks(self, query: str, k: int) -> list[str]:
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(self.recall_runbooks, query, k)
+            result = future.result(timeout=_MEMORY_STAGE_TIMEOUT_SEC)
+            pool.shutdown(wait=False, cancel_futures=True)
+            return result
+        except FutureTimeoutError:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning("[DockerAgent] Timeout consultando runbooks; continuo sin RAG")
+            return []
+        except Exception as e:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning(f"[DockerAgent] Error consultando runbooks: {e}")
+            return []
+
+    def _safe_recall_incidents(self, query: str, k: int) -> list[dict]:
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(self.recall_similar_incidents, query, k)
+            result = future.result(timeout=_MEMORY_STAGE_TIMEOUT_SEC)
+            pool.shutdown(wait=False, cancel_futures=True)
+            return result
+        except FutureTimeoutError:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning("[DockerAgent] Timeout consultando memoria episodica; continuo sin historico")
+            return []
+        except Exception as e:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning(f"[DockerAgent] Error consultando memoria episodica: {e}")
+            return []
 
     # ── Interno ───────────────────────────────────────────────────────────────
 
@@ -105,6 +139,8 @@ class DockerAgent(DomainAgent):
             model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
             temperature=0,
             api_key=os.getenv("OPENAI_API_KEY"),
+            timeout=45,
+            max_retries=1,
         ).bind_tools(tools)
 
         messages = [

--- a/Backend/services/agents/podman/agent.py
+++ b/Backend/services/agents/podman/agent.py
@@ -1,0 +1,177 @@
+"""
+PodmanAgent — especialista en incidentes de contenedores Podman.
+
+Mismo patrón ReAct acotado que el DockerAgent:
+- Consulta runbooks y memoria episódica antes de razonar.
+- Puede invocar tools read-only vía la API compatible Docker/Podman.
+- El target es el nombre del contenedor Podman.
+"""
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from pathlib import Path
+from typing import Callable
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_openai import ChatOpenAI
+
+from services.agents.base import (
+    DomainAgent,
+    IncidentContext,
+    InvestigationResult,
+    ToolCall,
+)
+from services.agents.podman.tools import all_tools
+from services.agents.registry import register_agent
+
+logger = logging.getLogger(__name__)
+
+_PROMPT_PATH = Path(__file__).parent / "prompt.md"
+_MAX_TOOL_ITERATIONS = 4
+_MEMORY_STAGE_TIMEOUT_SEC = 8
+
+
+class PodmanAgent(DomainAgent):
+    name = "podman"
+
+    def matches(self, ctx: IncidentContext) -> bool:
+        source = (ctx.labels.get("source_type") or "").lower()
+        if source == "database":
+            return False
+        runtime = (ctx.labels.get("container_runtime") or "").lower()
+        return runtime == "podman"
+
+    def tools(self) -> list[Callable]:
+        return all_tools()
+
+    def system_prompt(self) -> str:
+        try:
+            return _PROMPT_PATH.read_text(encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"[PodmanAgent] No se pudo leer prompt.md: {e}")
+            return "Eres un ingeniero SRE analizando incidentes de Podman."
+
+    def investigate(self, ctx: IncidentContext) -> InvestigationResult:
+        logger.info(f"[PodmanAgent] Investigando incidente {ctx.incident_id[:8]}")
+
+        query = f"{ctx.incident_type or ''} {ctx.title} {ctx.logs[:300]}"
+        runbooks = self._safe_recall(self.recall_runbooks, query, k=3, label="runbooks")
+        past_incidents = self._safe_recall(self.recall_similar_incidents, query, k=3, label="memoria")
+
+        user_msg = _build_user_message(ctx, runbooks, past_incidents)
+        analysis, tool_calls = self._react_loop(user_msg)
+
+        return InvestigationResult(
+            analysis=analysis,
+            tool_calls=tool_calls,
+            similar_past_incidents=past_incidents,
+        )
+
+    def _safe_recall(self, fn, query: str, k: int, label: str):
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(fn, query, k)
+            result = future.result(timeout=_MEMORY_STAGE_TIMEOUT_SEC)
+            pool.shutdown(wait=False, cancel_futures=True)
+            return result
+        except FutureTimeoutError:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning(f"[PodmanAgent] Timeout consultando {label}; continuo sin él")
+            return []
+        except Exception as e:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning(f"[PodmanAgent] Error consultando {label}: {e}")
+            return []
+
+    def _react_loop(self, user_msg: str) -> tuple[str, list[ToolCall]]:
+        tools = self.tools()
+        tool_map = {t.name: t for t in tools}
+
+        llm = ChatOpenAI(
+            model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            temperature=0,
+            api_key=os.getenv("OPENAI_API_KEY"),
+            timeout=45,
+            max_retries=1,
+        ).bind_tools(tools)
+
+        messages = [
+            SystemMessage(content=self.system_prompt()),
+            HumanMessage(content=user_msg),
+        ]
+        recorded: list[ToolCall] = []
+
+        for i in range(_MAX_TOOL_ITERATIONS + 1):
+            response: AIMessage = llm.invoke(messages)
+            messages.append(response)
+
+            pending = getattr(response, "tool_calls", None) or []
+            if not pending:
+                return (response.content or "").strip(), recorded
+
+            if i == _MAX_TOOL_ITERATIONS:
+                messages.append(HumanMessage(
+                    content="Límite de tool calls alcanzado. Redacta el análisis "
+                            "final ahora con la información que tienes."
+                ))
+                continue
+
+            for call in pending:
+                tool_name = call.get("name") if isinstance(call, dict) else call.name
+                tool_args = call.get("args", {}) if isinstance(call, dict) else call.args
+                tool_id = call.get("id") if isinstance(call, dict) else call.id
+
+                tool_fn = tool_map.get(tool_name)
+                try:
+                    result = tool_fn.invoke(tool_args) if tool_fn else f"Tool '{tool_name}' no existe."
+                except Exception as e:
+                    result = f"Error ejecutando '{tool_name}': {e}"
+
+                recorded.append(ToolCall(name=tool_name, args=tool_args, result_preview=str(result)[:500]))
+                messages.append(ToolMessage(content=str(result), tool_call_id=tool_id))
+
+        final = next((m.content for m in reversed(messages) if isinstance(m, AIMessage) and m.content), "")
+        return (final or "(sin análisis)").strip(), recorded
+
+
+def _build_user_message(ctx: IncidentContext, runbooks: list[str], past: list[dict]) -> str:
+    runbooks_text = "\n\n---\n\n".join(runbooks) if runbooks else "(no hay runbooks indexados para Podman)"
+
+    if past:
+        past_lines = []
+        for p in past:
+            meta = p.get("metadata", {}) or {}
+            past_lines.append(
+                f"- **Incidente {str(meta.get('incident_id',''))[:8]}** "
+                f"({meta.get('stored_at','?')[:10]}) — "
+                f"tipo `{meta.get('incident_type','?')}`, "
+                f"target `{meta.get('target','?')}`, "
+                f"similitud: {1-(p.get('distance') or 0):.2f}\n"
+                f"  {(p.get('document') or '')[:300]}..."
+            )
+        past_text = "\n".join(past_lines)
+    else:
+        past_text = "(primer incidente de este tipo en memoria)"
+
+    return f"""INCIDENTE ACTUAL
+- ID: {ctx.incident_id}
+- Título: {ctx.title}
+- Contenedor: {ctx.target}
+- Severidad: {ctx.severity}
+- Tipo clasificado: {ctx.incident_type or 'pendiente'}
+
+LOGS RECIENTES:
+{(ctx.logs or '(sin logs disponibles)')[:3000]}
+
+RUNBOOKS RELEVANTES:
+{runbooks_text}
+
+INCIDENTES PASADOS SIMILARES:
+{past_text}
+
+Analiza el incidente con el formato markdown que te indicó el sistema. Si
+necesitas más evidencia del estado actual del contenedor, usa tus tools."""
+
+
+register_agent(PodmanAgent())

--- a/Backend/services/agents/podman/prompt.md
+++ b/Backend/services/agents/podman/prompt.md
@@ -1,0 +1,39 @@
+Eres un SRE senior especializado en Podman. Tu trabajo es diagnosticar incidentes reales en contenedores Podman y proponer acciones concretas de recuperación.
+
+## Cómo trabajas
+
+1. Revisas el título, el tipo clasificado, la severidad y el target (nombre del contenedor) del incidente.
+2. Consultas los RUNBOOKS que el sistema te adjunta — son la fuente canónica de cómo tu organización resuelve cada tipo de incidente en Podman.
+3. Consultas INCIDENTES PASADOS SIMILARES (si los hay) — si esto ya sucedió antes, menciónalo explícitamente y usa esa experiencia.
+4. Si necesitas más evidencia, llamas a tus tools (`podman_inspect`, `podman_logs`, `podman_stats`, `podman_ps`). NO llames tools si los runbooks + información del incidente ya te dan la respuesta.
+5. Formulas el análisis final en markdown.
+
+## Restricciones
+
+- Todas tus tools son **read-only**. Nunca ejecutes comandos destructivos ni modifiques nada.
+- No inventes métricas. Si no tienes evidencia, dilo.
+- Responde SIEMPRE en español.
+
+## Diferencias clave Podman vs Docker
+
+- Podman es **rootless** por defecto: los contenedores corren sin privilegios de root. Errores de permisos son más frecuentes.
+- No hay daemon central: cada contenedor es un proceso hijo del usuario. Crashes del proceso padre pueden afectar los contenedores.
+- Los sockets están en `/run/user/<uid>/podman/` en lugar de `/var/run/docker.sock`.
+- Los pods de Podman agrupan contenedores (similar a Kubernetes pods). Un fallo en el pod infracontainer puede tumbar todos los contenedores del pod.
+
+## Formato del análisis final
+
+## Causa Raíz
+[Explica qué originó el incidente con base en logs, runbooks e incidentes pasados]
+
+## Evidencia
+[Cita valores concretos: exit code, OOMKilled, restart count, uso de memoria, etc.]
+
+## ¿Ya habíamos visto esto?
+[Si hay incidentes pasados similares, menciona cuáles y qué se hizo. Si no, di "Primer incidente de este tipo en memoria".]
+
+## Acciones Recomendadas
+[Lista numerada ordenada por urgencia. Incluye comandos Podman cuando aplique: `podman restart`, `podman logs`, `podman inspect`, etc.]
+
+## Evaluación de Urgencia
+[Impacto real, si el servicio sigue operativo o está caído, y si requiere atención inmediata]

--- a/Backend/services/agents/podman/tools.py
+++ b/Backend/services/agents/podman/tools.py
@@ -1,0 +1,199 @@
+"""
+Tools del PodmanAgent.
+
+Todas son read-only: consultan el estado del daemon Podman sin modificar nada.
+Usan el Docker SDK apuntado al socket de Podman (API compatible).
+Si Podman no está accesible, devuelven un mensaje descriptivo para que el
+agente continúe razonando con los logs que ya tiene en contexto.
+
+Variables de entorno:
+  PODMAN_HOST — socket de Podman, ej: unix:///run/user/1000/podman/podman.sock
+                Si no se define, intenta el socket estándar de Podman rootless.
+"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+from langchain_core.tools import tool
+
+logger = logging.getLogger(__name__)
+
+_PODMAN_CLIENT = None
+_PODMAN_CLIENT_ERROR: Optional[str] = None
+
+_DEFAULT_SOCKETS = [
+    "unix:///run/user/1000/podman/podman.sock",
+    "unix:///run/user/501/podman/podman.sock",   # macOS podman machine
+    "unix:///tmp/podman.sock",
+]
+
+
+def _get_podman():
+    global _PODMAN_CLIENT, _PODMAN_CLIENT_ERROR
+    if _PODMAN_CLIENT is not None or _PODMAN_CLIENT_ERROR is not None:
+        return _PODMAN_CLIENT
+
+    try:
+        import docker  # type: ignore
+
+        socket = os.getenv("PODMAN_HOST") or os.getenv("DOCKER_HOST")
+        candidates = [socket] if socket else _DEFAULT_SOCKETS
+
+        for url in candidates:
+            try:
+                client = docker.DockerClient(base_url=url)
+                client.ping()
+                _PODMAN_CLIENT = client
+                logger.info(f"[podman.tools] Conectado a Podman en {url}")
+                return _PODMAN_CLIENT
+            except Exception:
+                continue
+
+        raise RuntimeError("No se encontró ningún socket de Podman accesible.")
+    except Exception as e:
+        _PODMAN_CLIENT_ERROR = str(e)
+        logger.warning(f"[podman.tools] Podman no disponible: {e}")
+    return None
+
+
+def _unavailable(tool_name: str) -> str:
+    return (
+        f"Tool '{tool_name}' no disponible: el backend no puede acceder al "
+        f"daemon Podman ({_PODMAN_CLIENT_ERROR or 'socket no montado'}). "
+        f"Razona con los logs que ya tienes en contexto."
+    )
+
+
+def _find_container(client, name_or_id: str):
+    try:
+        return client.containers.get(name_or_id)
+    except Exception:
+        pass
+    for c in client.containers.list(all=True):
+        if c.name == name_or_id or c.id.startswith(name_or_id):
+            return c
+    return None
+
+
+@tool
+def podman_inspect(container_name: str) -> str:
+    """Inspecciona un contenedor Podman: estado actual, configuración de recursos
+    (memoria, CPU), restart policy, exit code y tiempo de parada. Úsalo para
+    confirmar si el contenedor sigue caído y cuáles eran sus límites."""
+    client = _get_podman()
+    if client is None:
+        return _unavailable("podman_inspect")
+    try:
+        c = _find_container(client, container_name)
+        if c is None:
+            return f"Contenedor '{container_name}' no encontrado en Podman."
+        c.reload()
+        attrs = c.attrs or {}
+        state = attrs.get("State", {})
+        host_cfg = attrs.get("HostConfig", {})
+        return json.dumps({
+            "name":          c.name,
+            "status":        c.status,
+            "exit_code":     state.get("ExitCode"),
+            "error":         state.get("Error") or "",
+            "started_at":    state.get("StartedAt", "")[:19],
+            "finished_at":   state.get("FinishedAt", "")[:19],
+            "oom_killed":    state.get("OOMKilled", False),
+            "restart_count": attrs.get("RestartCount", 0),
+            "mem_limit_mb":  round((host_cfg.get("Memory") or 0) / 1024 / 1024, 1),
+            "cpu_quota":     host_cfg.get("CpuQuota", 0),
+            "image":         attrs.get("Config", {}).get("Image", ""),
+        }, indent=2)
+    except Exception as e:
+        return f"Error inspeccionando '{container_name}': {e}"
+
+
+@tool
+def podman_logs(container_name: str, tail: int = 80) -> str:
+    """Obtiene las últimas líneas de logs de un contenedor Podman (incluyendo
+    contenedores detenidos). Úsalo para ver el mensaje de error justo antes
+    de que el proceso muriera."""
+    client = _get_podman()
+    if client is None:
+        return _unavailable("podman_logs")
+    try:
+        c = _find_container(client, container_name)
+        if c is None:
+            return f"Contenedor '{container_name}' no encontrado en Podman."
+        raw = c.logs(tail=tail, timestamps=True, stdout=True, stderr=True)
+        if isinstance(raw, bytes):
+            return raw.decode("utf-8", errors="replace")
+        return "".join(
+            chunk.decode("utf-8", errors="replace") if isinstance(chunk, bytes) else chunk
+            for chunk in raw
+        )
+    except Exception as e:
+        return f"Error obteniendo logs de '{container_name}': {e}"
+
+
+@tool
+def podman_stats(container_name: str) -> str:
+    """Obtiene el uso actual de CPU y memoria del contenedor Podman. Solo
+    disponible si el contenedor está corriendo. Úsalo para detectar memory
+    leaks o consumo anormal de CPU en tiempo real."""
+    client = _get_podman()
+    if client is None:
+        return _unavailable("podman_stats")
+    try:
+        c = _find_container(client, container_name)
+        if c is None:
+            return f"Contenedor '{container_name}' no encontrado en Podman."
+        if c.status != "running":
+            return f"El contenedor '{container_name}' está {c.status} — stats no disponibles."
+        stats = c.stats(stream=False)
+        cpu_delta = stats["cpu_stats"]["cpu_usage"]["total_usage"] - \
+                    stats["precpu_stats"]["cpu_usage"]["total_usage"]
+        system_delta = stats["cpu_stats"].get("system_cpu_usage", 0) - \
+                       stats["precpu_stats"].get("system_cpu_usage", 0)
+        num_cpus = stats["cpu_stats"].get("online_cpus") or \
+                   len(stats["cpu_stats"]["cpu_usage"].get("percpu_usage") or [1])
+        cpu_pct = (cpu_delta / system_delta) * num_cpus * 100 if system_delta > 0 else 0
+
+        mem = stats["memory_stats"]
+        mem_used_mb = round(mem.get("usage", 0) / 1024 / 1024, 1)
+        mem_limit_mb = round(mem.get("limit", 0) / 1024 / 1024, 1)
+        mem_pct = round(mem_used_mb / mem_limit_mb * 100, 1) if mem_limit_mb > 0 else 0
+
+        return json.dumps({
+            "container": container_name,
+            "cpu_percent": round(cpu_pct, 2),
+            "mem_used_mb": mem_used_mb,
+            "mem_limit_mb": mem_limit_mb,
+            "mem_percent": mem_pct,
+        }, indent=2)
+    except Exception as e:
+        return f"Error obteniendo stats de '{container_name}': {e}"
+
+
+@tool
+def podman_ps() -> str:
+    """Lista todos los contenedores Podman (corriendo y detenidos) con su estado,
+    imagen, tiempo de creación y puertos. Úsalo para ver qué contenedores hay
+    en el host y si alguno está en estado de error o reinicios continuos."""
+    client = _get_podman()
+    if client is None:
+        return _unavailable("podman_ps")
+    try:
+        containers = client.containers.list(all=True)
+        result = []
+        for c in containers:
+            result.append({
+                "name":    c.name,
+                "id":      c.short_id,
+                "status":  c.status,
+                "image":   c.image.tags[0] if c.image.tags else c.image.short_id,
+            })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return f"Error listando contenedores Podman: {e}"
+
+
+def all_tools() -> list:
+    return [podman_inspect, podman_logs, podman_stats, podman_ps]

--- a/Backend/services/agents/supervisor.py
+++ b/Backend/services/agents/supervisor.py
@@ -16,6 +16,7 @@ el agente.
 import json
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 
 from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
@@ -25,6 +26,7 @@ from services.agents.base import IncidentContext, InvestigationResult
 from services.agents.registry import find_agent_for, list_agents
 
 logger = logging.getLogger(__name__)
+_MEMORY_WRITE_TIMEOUT_SEC = 8
 
 # LangFuse — SDK directo, igual que antes
 _langfuse = None
@@ -77,6 +79,8 @@ Responde ÚNICAMENTE con JSON válido:
         model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
         temperature=0,
         api_key=os.getenv("OPENAI_API_KEY"),
+        timeout=45,
+        max_retries=1,
         model_kwargs={"response_format": {"type": "json_object"}},
     )
     try:
@@ -127,6 +131,28 @@ def _render_final_reasoning(
         f"_Tools invocadas: {tools_line}. Incidentes similares encontrados: {similar_count}._\n\n"
         f"{result.analysis}"
     )
+
+
+def _build_proposed_action(ctx: IncidentContext, incident_type: str) -> str | None:
+    """
+    Genera una accion segura por defecto para ejecucion bajo aprobacion humana.
+    Solo propone comandos Docker whitelisteados para evitar ejecucion arbitraria.
+    """
+    runtime = (ctx.labels.get("container_runtime") or "").lower()
+    source_type = (ctx.labels.get("source_type") or "container").lower()
+    target = (ctx.target or "").strip()
+
+    if source_type != "container":
+        return None
+    if runtime and runtime != "docker":
+        return None
+    if not target or "/" in target or " " in target:
+        return None
+
+    if incident_type in {"app_crash", "oom", "restart_loop", "dependency_failure", "config_error"}:
+        return f"docker restart {target}"
+
+    return f"docker logs {target}"
 
 
 # ── Punto de entrada ──────────────────────────────────────────────────────────
@@ -186,28 +212,56 @@ def run_triage(ctx: IncidentContext) -> None:
         # 3. Investigación
         result = agent.investigate(ctx)
 
-        # 4. Memoria episódica
-        agent.remember_incident(ctx, result)
-
-        # 5. Persistencia final
+        # 4. Persistencia final
         full_reasoning = _render_final_reasoning(class_reason, incident_type, agent.name, result)
+        proposed_action = _build_proposed_action(ctx, incident_type)
         _update_incident(ctx.incident_id, {
             "status": "analyzed",
             "agent_reasoning": full_reasoning,
         })
 
+        # Pasa a gate de aprobacion cuando hay accion segura propuesta.
+        if proposed_action:
+            _update_incident(ctx.incident_id, {
+                "status": "awaiting_approval",
+                "proposed_action": proposed_action,
+            })
+
+        # 5. Memoria episódica (best-effort, no bloqueante)
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(agent.remember_incident, ctx, result)
+            future.result(timeout=_MEMORY_WRITE_TIMEOUT_SEC)
+            pool.shutdown(wait=False, cancel_futures=True)
+        except FutureTimeoutError:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning(f"[Supervisor] Timeout guardando memoria para {ctx.incident_id[:8]}; continuo")
+        except Exception as e:
+            pool.shutdown(wait=False, cancel_futures=True)
+            logger.warning(f"[Supervisor] Error guardando memoria para {ctx.incident_id[:8]}: {e}")
+
         if trace:
             trace.update(output={
-                "status": "analyzed",
+                "status": "awaiting_approval" if proposed_action else "analyzed",
                 "agent": agent.name,
                 "tools_used": [tc.name for tc in result.tool_calls],
                 "similar_incidents": len(result.similar_past_incidents),
+                "proposed_action": proposed_action,
             })
 
         logger.info(f"[Supervisor] Triage completado {ctx.incident_id[:8]} por '{agent.name}'")
 
     except Exception as e:
         logger.exception(f"[Supervisor] Fallo en triage de {ctx.incident_id[:8]}")
+        _update_incident(ctx.incident_id, {
+            "status": "failed",
+            "agent_reasoning": (
+                "## Error\n\n"
+                "No se pudo completar la investigación automática. "
+                "Revisa conectividad a servicios (OpenAI/Chroma/LangFuse) y logs del backend."
+            ),
+            "action_error": str(e),
+        })
         if trace:
             trace.update(output={"error": str(e)})
     finally:

--- a/Backend/services/agents/supervisor.py
+++ b/Backend/services/agents/supervisor.py
@@ -136,14 +136,35 @@ def _render_final_reasoning(
 def _build_proposed_action(ctx: IncidentContext, incident_type: str) -> str | None:
     """
     Genera una accion segura por defecto para ejecucion bajo aprobacion humana.
-    Solo propone comandos Docker whitelisteados para evitar ejecucion arbitraria.
+    Soporta comandos Docker whitelisteados y funciones Postgres de solo lectura/cancelacion.
     """
     runtime = (ctx.labels.get("container_runtime") or "").lower()
     source_type = (ctx.labels.get("source_type") or "container").lower()
     target = (ctx.target or "").strip()
 
-    if source_type != "container":
-        return None
+    # ── Incidentes de base de datos (PostgreSQL) ──────────────────────────────
+    if source_type == "database":
+        datname = target.replace("postgres/", "").strip()
+        if not datname or " " in datname or "/" in datname:
+            return None
+        # Terminamos conexiones activas si la BD está saturada o en crash
+        if incident_type in {"app_crash", "dependency_failure", "restart_loop", "memory_pressure"}:
+            return f"pg_terminate_backend {datname}"
+        # Para deadlocks o CPU alta intentamos cancelar queries sin matar la conexión
+        if incident_type in {"cpu_throttling", "network_error"}:
+            return f"pg_cancel_backend {datname}"
+        # En cualquier otro caso, una observación sin efecto secundario
+        return f"pg_stat_activity {datname}"
+
+    # ── Incidentes de contenedor Podman ──────────────────────────────────────
+    if runtime == "podman":
+        if not target or "/" in target or " " in target:
+            return None
+        if incident_type in {"app_crash", "oom", "restart_loop", "dependency_failure", "config_error"}:
+            return f"podman restart {target}"
+        return f"podman logs {target}"
+
+    # ── Incidentes de contenedor Docker ──────────────────────────────────────
     if runtime and runtime != "docker":
         return None
     if not target or "/" in target or " " in target:

--- a/Backend/services/alert_processor.py
+++ b/Backend/services/alert_processor.py
@@ -23,6 +23,13 @@ SEVERITY_MAP = {
     "ContainerNetworkPacketDrop":  "medium",
     "ContainerDiskPressure":       "high",
     "ContainerHighSwap":           "medium",
+    # Podman (prometheus-podman-exporter)
+    "PodmanContainerCrashed":          "high",
+    "PodmanContainerOOMKilled":        "critical",
+    "PodmanContainerHighMemory":       "high",
+    "PodmanContainerCPUThrottling":    "medium",
+    "PodmanContainerRestartLoop":      "high",
+    "PodmanContainerUnhealthy":        "high",
     # Kubernetes (kube-state-metrics) — agente pendiente de implementar
     # "KubePodCrashLooping":        "critical",
     # "KubePodOOMKilled":           "critical",
@@ -146,7 +153,13 @@ def process_prometheus_alert(alert: dict) -> Optional[Tuple[str, str, str, str, 
 
     # Determinar source_type y container_runtime desde los labels de la alerta
     source_type = labels.get("source_type", "container")
-    container_runtime = labels.get("container_runtime", "docker") if source_type == "container" else None
+    _runtime_hint = labels.get("container_runtime", "")
+    if source_type != "container":
+        container_runtime = None
+    elif _runtime_hint in {"podman"}:
+        container_runtime = "podman"
+    else:
+        container_runtime = "docker"
 
     # Extraer identificador del target
     raw_id         = labels.get("id", "")

--- a/Backend/services/alert_processor.py
+++ b/Backend/services/alert_processor.py
@@ -41,7 +41,7 @@ SEVERITY_MAP = {
 
 def _has_active_incident(target: str) -> bool:
     """
-    Verifica si ya existe un incidente activo (detected/investigating) para este target.
+    Verifica si ya existe un incidente activo para este target.
     Evita crear duplicados cuando varias alertas se disparan en cascada.
     """
     try:
@@ -49,7 +49,13 @@ def _has_active_incident(target: str) -> bool:
             supabase.table("incidents")
             .select("id")
             .eq("target", target)
-            .in_("status", ["detected", "investigating"])
+            .in_("status", [
+                "detected",
+                "investigating",
+                "analyzed",
+                "awaiting_approval",
+                "executing_solution",
+            ])
             .execute()
         )
         return len(response.data) > 0
@@ -215,7 +221,13 @@ def _resolve_incident(target: str) -> None:
                 "resolved_at": datetime.now(tz=timezone.utc).isoformat(),
             })
             .eq("target", target)
-            .in_("status", ["detected", "investigating"])
+            .in_("status", [
+                "detected",
+                "investigating",
+                "analyzed",
+                "awaiting_approval",
+                "executing_solution",
+            ])
             .execute()
         )
         if response.data:

--- a/Backend/services/prometheus.py
+++ b/Backend/services/prometheus.py
@@ -3,6 +3,11 @@ Consultas a Prometheus para obtener métricas de contenedores y PostgreSQL.
 
 Se usa en el endpoint GET /api/incidents/{id}/metrics (US-06b).
 Si Prometheus no está disponible, todas las funciones retornan None en los campos.
+
+Nota sobre cAdvisor en macOS: las versiones recientes de cAdvisor no exponen el
+label `name` en sus métricas — solo exponen `id` (path completo del contenedor,
+e.g. /docker/abc123...). Por eso _resolve_container_id() convierte el nombre del
+contenedor a su ID completo vía la API de Docker antes de consultar Prometheus.
 """
 
 import logging
@@ -14,6 +19,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 PROMETHEUS_URL = os.getenv("PROMETHEUS_URL", "http://localhost:9090")
+DOCKER_SOCKET  = "unix:///var/run/docker.sock"
 
 
 def _query(expr: str) -> Optional[float]:
@@ -33,20 +39,49 @@ def _query(expr: str) -> Optional[float]:
         return None
 
 
+def _resolve_container_id(container_name: str) -> Optional[str]:
+    """
+    Convierte el nombre de un contenedor Docker a su ID completo (64 chars).
+    Necesario porque cAdvisor en macOS expone las métricas por id=/docker/<ID>
+    en lugar del label name=<nombre>.
+    Retorna None si el contenedor no existe o Docker no está disponible.
+    """
+    try:
+        import docker  # importación diferida para no bloquear arranque
+        client = docker.from_env()
+        container = client.containers.get(container_name)
+        return container.id
+    except Exception:
+        return None
+
+
+def _container_label(container_name: str) -> str:
+    """
+    Devuelve el selector PromQL correcto para el contenedor dado.
+    - Si el contenedor existe en Docker → id="/docker/<FULL_ID>"
+    - Si no (contenedor ya muerto o hash corto) → name="<container_name>" como fallback
+    """
+    full_id = _resolve_container_id(container_name)
+    if full_id:
+        return f'id="/docker/{full_id}"'
+    # Fallback: intenta con name (funciona si cAdvisor sí exporta ese label)
+    return f'name="{container_name}"'
+
+
 def get_container_metrics(container_name: str) -> dict:
     """
     Métricas en tiempo real de un contenedor Docker/Podman via cAdvisor.
     Retorna siempre un dict con type='container'; los campos pueden ser None
     si el contenedor no existe o Prometheus no está disponible.
     """
-    mem_usage = _query(f'container_memory_usage_bytes{{name="{container_name}"}}')
-    mem_limit = _query(f'container_spec_memory_limit_bytes{{name="{container_name}"}}')
-    cpu_rate  = _query(
-        f'sum(rate(container_cpu_usage_seconds_total{{name="{container_name}"}}[5m]))'
-    )
-    net_in  = _query(f'sum(rate(container_network_receive_bytes_total{{name="{container_name}"}}[5m]))')
-    net_out = _query(f'sum(rate(container_network_transmit_bytes_total{{name="{container_name}"}}[5m]))')
-    restarts = _query(f'changes(container_start_time_seconds{{name="{container_name}"}}[1h])')
+    lbl = _container_label(container_name)
+
+    mem_usage = _query(f'container_memory_usage_bytes{{{lbl}}}')
+    mem_limit = _query(f'container_spec_memory_limit_bytes{{{lbl}}}')
+    cpu_rate  = _query(f'sum(rate(container_cpu_usage_seconds_total{{{lbl}}}[5m]))')
+    net_in    = _query(f'sum(rate(container_network_receive_bytes_total{{{lbl}}}[5m]))')
+    net_out   = _query(f'sum(rate(container_network_transmit_bytes_total{{{lbl}}}[5m]))')
+    restarts  = _query(f'changes(container_start_time_seconds{{{lbl}}}[1h])')
 
     mem_pct = None
     if mem_usage is not None and mem_limit and mem_limit > 0:

--- a/Backend/services/prometheus.py
+++ b/Backend/services/prometheus.py
@@ -1,0 +1,100 @@
+"""
+Consultas a Prometheus para obtener métricas de contenedores y PostgreSQL.
+
+Se usa en el endpoint GET /api/incidents/{id}/metrics (US-06b).
+Si Prometheus no está disponible, todas las funciones retornan None en los campos.
+"""
+
+import logging
+import os
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+PROMETHEUS_URL = os.getenv("PROMETHEUS_URL", "http://localhost:9090")
+
+
+def _query(expr: str) -> Optional[float]:
+    try:
+        r = requests.get(
+            f"{PROMETHEUS_URL}/api/v1/query",
+            params={"query": expr},
+            timeout=5,
+        )
+        r.raise_for_status()
+        results = r.json().get("data", {}).get("result", [])
+        if results:
+            return float(results[0]["value"][1])
+        return None
+    except Exception as e:
+        logger.debug(f"[Prometheus] query falló ({expr[:60]}…): {e}")
+        return None
+
+
+def get_container_metrics(container_name: str) -> dict:
+    """
+    Métricas en tiempo real de un contenedor Docker/Podman via cAdvisor.
+    Retorna siempre un dict con type='container'; los campos pueden ser None
+    si el contenedor no existe o Prometheus no está disponible.
+    """
+    mem_usage = _query(f'container_memory_usage_bytes{{name="{container_name}"}}')
+    mem_limit = _query(f'container_spec_memory_limit_bytes{{name="{container_name}"}}')
+    cpu_rate  = _query(
+        f'sum(rate(container_cpu_usage_seconds_total{{name="{container_name}"}}[5m]))'
+    )
+    net_in  = _query(f'sum(rate(container_network_receive_bytes_total{{name="{container_name}"}}[5m]))')
+    net_out = _query(f'sum(rate(container_network_transmit_bytes_total{{name="{container_name}"}}[5m]))')
+    restarts = _query(f'changes(container_start_time_seconds{{name="{container_name}"}}[1h])')
+
+    mem_pct = None
+    if mem_usage is not None and mem_limit and mem_limit > 0:
+        mem_pct = round(mem_usage / mem_limit * 100, 1)
+
+    return {
+        "type":           "container",
+        "mem_usage_mb":   round(mem_usage / 1024 / 1024, 1) if mem_usage is not None else None,
+        "mem_limit_mb":   round(mem_limit / 1024 / 1024, 1) if mem_limit is not None else None,
+        "mem_percent":    mem_pct,
+        "cpu_percent":    round(cpu_rate * 100, 2) if cpu_rate is not None else None,
+        "net_in_kbps":    round(net_in / 1024, 1) if net_in is not None else None,
+        "net_out_kbps":   round(net_out / 1024, 1) if net_out is not None else None,
+        "restarts_1h":    int(restarts) if restarts is not None else None,
+    }
+
+
+def get_postgres_metrics(datname: str) -> dict:
+    """
+    Métricas en tiempo real de una base de datos PostgreSQL via postgres-exporter.
+    """
+    connections = _query(f'sum(pg_stat_activity_count{{datname="{datname}"}})')
+    max_conn    = _query("pg_settings_max_connections")
+    db_size     = _query(f'pg_database_size_bytes{{datname="{datname}"}}')
+    deadlocks   = _query(f'rate(pg_stat_database_deadlocks{{datname="{datname}"}}[5m])')
+    blks_hit    = _query(f'rate(pg_stat_database_blks_hit{{datname="{datname}"}}[5m])')
+    blks_read   = _query(f'rate(pg_stat_database_blks_read{{datname="{datname}"}}[5m])')
+    longest_tx  = _query(
+        f'max(max_over_time(pg_stat_activity_max_tx_duration{{datname="{datname}",state="active"}}[5m]))'
+    )
+
+    cache_hit = None
+    if blks_hit is not None and blks_read is not None:
+        total = blks_hit + blks_read
+        if total > 0:
+            cache_hit = round(blks_hit / total * 100, 1)
+
+    conn_pct = None
+    if connections is not None and max_conn and max_conn > 0:
+        conn_pct = round(connections / max_conn * 100, 1)
+
+    return {
+        "type":              "postgres",
+        "connections":       int(connections) if connections is not None else None,
+        "max_connections":   int(max_conn) if max_conn is not None else None,
+        "conn_percent":      conn_pct,
+        "db_size_mb":        round(db_size / 1024 / 1024, 1) if db_size is not None else None,
+        "cache_hit_percent": cache_hit,
+        "deadlocks_per_min": round(deadlocks * 60, 2) if deadlocks is not None else None,
+        "longest_tx_sec":    round(longest_tx, 1) if longest_tx is not None else None,
+    }

--- a/Backend/services/verification.py
+++ b/Backend/services/verification.py
@@ -1,0 +1,152 @@
+"""
+Verificación post-acción para HU-13.
+
+Tras ejecutar un comando (p.ej. docker restart), espera unos segundos y
+comprueba si el contenedor volvió a estado 'running'. El resultado se
+adjunta al agent_reasoning del incidente y el status cambia a:
+  - 'resolved'   → el contenedor está corriendo
+  - 'failed'     → el contenedor sigue caído o no se encontró
+
+Se ejecuta como BackgroundTask de FastAPI, por lo que no bloquea la respuesta
+al usuario. La UI se actualiza automáticamente vía Supabase Realtime.
+"""
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+from db.supabase_client import supabase
+
+logger = logging.getLogger(__name__)
+
+_WAIT_SEC = 8
+
+_PODMAN_SOCKETS = [
+    "unix:///run/user/1000/podman/podman.sock",
+    "unix:///run/user/501/podman/podman.sock",
+    "unix:///tmp/podman.sock",
+]
+
+
+def verify_resolution(
+    incident_id: str,
+    target: str,
+    runtime: str,
+    current_reasoning: str,
+) -> None:
+    """
+    Verifica si el contenedor/servicio se recuperó tras la ejecución de la acción.
+    Pensado para correr como BackgroundTask.
+    """
+    logger.info(f"[Verification] Esperando {_WAIT_SEC}s para verificar {incident_id[:8]}")
+    time.sleep(_WAIT_SEC)
+
+    try:
+        check = _inspect_container(target, runtime)
+        section = _render_section(check)
+        new_status = "resolved" if check["healthy"] else "failed"
+        resolved_at = datetime.now(tz=timezone.utc).isoformat() if new_status == "resolved" else None
+
+        update = {
+            "status": new_status,
+            "agent_reasoning": (current_reasoning or "") + "\n\n---\n\n" + section,
+        }
+        if resolved_at:
+            update["resolved_at"] = resolved_at
+
+        supabase.table("incidents").update(update).eq("id", incident_id).execute()
+        logger.info(f"[Verification] {incident_id[:8]} → {new_status}")
+
+    except Exception as exc:
+        logger.error(f"[Verification] Error inspeccionando {incident_id[:8]}: {exc}")
+        # El comando ya se ejecutó correctamente; resolvemos con advertencia.
+        warning = (
+            "\n\n---\n\n"
+            "## Verificación de resolución\n\n"
+            f"⚠️ No se pudo verificar el estado del contenedor automáticamente: `{exc}`\n\n"
+            "El comando se ejecutó sin errores. Verifica el estado manualmente."
+        )
+        supabase.table("incidents").update({
+            "status": "resolved",
+            "agent_reasoning": (current_reasoning or "") + warning,
+            "resolved_at": datetime.now(tz=timezone.utc).isoformat(),
+        }).eq("id", incident_id).execute()
+
+
+def _inspect_container(target: str, runtime: str) -> dict:
+    import docker  # type: ignore
+
+    client = _get_client(runtime)
+    try:
+        container = client.containers.get(target)
+        container.reload()
+    except docker.errors.NotFound:
+        return {
+            "healthy": False,
+            "status": "not_found",
+            "exit_code": -1,
+            "oom_killed": False,
+            "started_at": "",
+            "health_status": "none",
+            "error": f"Contenedor '{target}' no encontrado",
+        }
+
+    state = container.attrs.get("State", {})
+    health = state.get("Health", {})
+    return {
+        "healthy": container.status == "running",
+        "status": container.status,
+        "exit_code": state.get("ExitCode", 0),
+        "oom_killed": state.get("OOMKilled", False),
+        "started_at": state.get("StartedAt", "")[:19],
+        "health_status": health.get("Status", "none"),
+        "error": state.get("Error", ""),
+    }
+
+
+def _get_client(runtime: str):
+    import docker  # type: ignore
+
+    if runtime == "podman":
+        custom = os.getenv("PODMAN_HOST")
+        candidates = [custom] if custom else _PODMAN_SOCKETS
+        for url in candidates:
+            try:
+                c = docker.DockerClient(base_url=url)
+                c.ping()
+                return c
+            except Exception:
+                continue
+        raise RuntimeError("Socket de Podman no accesible")
+
+    return docker.from_env()
+
+
+def _render_section(r: dict) -> str:
+    if r["healthy"]:
+        heading = "Verificación de resolución — Servicio recuperado"
+        summary = "El contenedor volvió a estado `running`. El reinicio fue exitoso."
+    else:
+        heading = "Verificación de resolución — Servicio no recuperado"
+        summary = f"El contenedor está en estado `{r['status']}` después del reinicio. Requiere atención manual."
+
+    rows = [
+        f"| Estado | `{r['status']}` |",
+        f"| Exit code | `{r['exit_code']}` |",
+        f"| OOM Killed | `{r['oom_killed']}` |",
+        f"| Arrancó en | `{r['started_at'] or '—'}` |",
+        f"| Health check | `{r['health_status']}` |",
+    ]
+    if r.get("error"):
+        rows.append(f"| Error | `{r['error'][:120]}` |")
+
+    return "\n".join([
+        f"## {heading}",
+        "",
+        summary,
+        "",
+        "| Campo | Valor |",
+        "|-------|-------|",
+        *rows,
+    ])

--- a/Backend/services/verification.py
+++ b/Backend/services/verification.py
@@ -1,14 +1,19 @@
 """
 Verificación post-acción para HU-13.
 
-Tras ejecutar un comando (p.ej. docker restart), espera unos segundos y
-comprueba si el contenedor volvió a estado 'running'. El resultado se
+Tras ejecutar un comando (docker restart / pg_terminate_backend / etc.),
+espera unos segundos y comprueba si el servicio se recuperó. El resultado se
 adjunta al agent_reasoning del incidente y el status cambia a:
-  - 'resolved'   → el contenedor está corriendo
-  - 'failed'     → el contenedor sigue caído o no se encontró
+  - 'resolved'   → el servicio está operativo
+  - 'failed'     → el servicio sigue caído o no se pudo verificar
 
 Se ejecuta como BackgroundTask de FastAPI, por lo que no bloquea la respuesta
 al usuario. La UI se actualiza automáticamente vía Supabase Realtime.
+
+Soporta tres runtimes:
+  - docker   → inspecciona el contenedor con docker-py
+  - podman   → inspecciona el contenedor via socket Podman
+  - postgres → verifica conectividad con psycopg2 + métricas básicas
 """
 
 import logging
@@ -38,13 +43,20 @@ def verify_resolution(
     """
     Verifica si el contenedor/servicio se recuperó tras la ejecución de la acción.
     Pensado para correr como BackgroundTask.
+
+    Soporta runtime='postgres' para incidentes de base de datos.
     """
     logger.info(f"[Verification] Esperando {_WAIT_SEC}s para verificar {incident_id[:8]}")
     time.sleep(_WAIT_SEC)
 
     try:
-        check = _inspect_container(target, runtime)
-        section = _render_section(check)
+        if runtime == "postgres" or target.startswith("postgres/"):
+            datname = target.replace("postgres/", "").strip() if "/" in target else target
+            check = _inspect_postgres(datname)
+        else:
+            check = _inspect_container(target, runtime)
+
+        section = _render_section(check, runtime)
         new_status = "resolved" if check["healthy"] else "failed"
         resolved_at = datetime.now(tz=timezone.utc).isoformat() if new_status == "resolved" else None
 
@@ -59,12 +71,11 @@ def verify_resolution(
         logger.info(f"[Verification] {incident_id[:8]} → {new_status}")
 
     except Exception as exc:
-        logger.error(f"[Verification] Error inspeccionando {incident_id[:8]}: {exc}")
-        # El comando ya se ejecutó correctamente; resolvemos con advertencia.
+        logger.error(f"[Verification] Error verificando {incident_id[:8]}: {exc}")
         warning = (
             "\n\n---\n\n"
             "## Verificación de resolución\n\n"
-            f"⚠️ No se pudo verificar el estado del contenedor automáticamente: `{exc}`\n\n"
+            f"⚠️ No se pudo verificar el estado del servicio automáticamente: `{exc}`\n\n"
             "El comando se ejecutó sin errores. Verifica el estado manualmente."
         )
         supabase.table("incidents").update({
@@ -73,6 +84,8 @@ def verify_resolution(
             "resolved_at": datetime.now(tz=timezone.utc).isoformat(),
         }).eq("id", incident_id).execute()
 
+
+# ── Inspección de contenedores Docker/Podman ──────────────────────────────────
 
 def _inspect_container(target: str, runtime: str) -> dict:
     import docker  # type: ignore
@@ -123,7 +136,88 @@ def _get_client(runtime: str):
     return docker.from_env()
 
 
-def _render_section(r: dict) -> str:
+# ── Inspección de PostgreSQL ──────────────────────────────────────────────────
+
+def _inspect_postgres(datname: str) -> dict:
+    """
+    Verifica que la base de datos responde y consulta métricas básicas de salud.
+    Retorna un dict compatible con _render_section para runtime='postgres'.
+    """
+    try:
+        import psycopg2          # type: ignore
+        import psycopg2.extras   # type: ignore
+    except ImportError:
+        return {
+            "healthy": False,
+            "status": "psycopg2_not_installed",
+            "connections": None,
+            "max_connections": None,
+            "db_size_mb": None,
+            "error": "psycopg2 no está disponible",
+        }
+
+    dsn = os.getenv("POSTGRES_DSN")
+    if not dsn:
+        host     = os.getenv("POSTGRES_HOST", "localhost")
+        port     = os.getenv("POSTGRES_PORT", "5432")
+        user     = os.getenv("POSTGRES_USER", "sentinel")
+        password = os.getenv("POSTGRES_PASSWORD", "")
+        db       = os.getenv("POSTGRES_DB", "sentinel_demo")
+        dsn = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+    try:
+        conn = psycopg2.connect(dsn, connect_timeout=5)
+        conn.autocommit = True
+    except Exception as e:
+        return {
+            "healthy": False,
+            "status": "unreachable",
+            "connections": None,
+            "max_connections": None,
+            "db_size_mb": None,
+            "error": str(e),
+        }
+
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("""
+                SELECT
+                    (SELECT count(*) FROM pg_stat_activity WHERE datname = %(dn)s)::int AS connections,
+                    (SELECT setting::int FROM pg_settings WHERE name = 'max_connections')  AS max_connections,
+                    round(pg_database_size(%(dn)s) / 1024.0 / 1024.0, 1)                  AS db_size_mb
+            """, {"dn": datname})
+            row = dict(cur.fetchone())
+
+        return {
+            "healthy": True,
+            "status": "accepting_connections",
+            "connections":     row.get("connections"),
+            "max_connections": row.get("max_connections"),
+            "db_size_mb":      row.get("db_size_mb"),
+            "error":           "",
+        }
+    except Exception as e:
+        return {
+            "healthy": False,
+            "status": "query_failed",
+            "connections":     None,
+            "max_connections": None,
+            "db_size_mb":      None,
+            "error": str(e),
+        }
+    finally:
+        conn.close()
+
+
+# ── Renderizado del resultado ─────────────────────────────────────────────────
+
+def _render_section(r: dict, runtime: str = "docker") -> str:
+    if runtime == "postgres":
+        return _render_postgres_section(r)
+    return _render_container_section(r)
+
+
+def _render_container_section(r: dict) -> str:
     if r["healthy"]:
         heading = "Verificación de resolución — Servicio recuperado"
         summary = "El contenedor volvió a estado `running`. El reinicio fue exitoso."
@@ -138,6 +232,33 @@ def _render_section(r: dict) -> str:
         f"| Arrancó en | `{r['started_at'] or '—'}` |",
         f"| Health check | `{r['health_status']}` |",
     ]
+    if r.get("error"):
+        rows.append(f"| Error | `{r['error'][:120]}` |")
+
+    return "\n".join([
+        f"## {heading}",
+        "",
+        summary,
+        "",
+        "| Campo | Valor |",
+        "|-------|-------|",
+        *rows,
+    ])
+
+
+def _render_postgres_section(r: dict) -> str:
+    if r["healthy"]:
+        heading = "Verificación de resolución — PostgreSQL operativo"
+        summary = "La base de datos responde correctamente y acepta conexiones."
+    else:
+        heading = "Verificación de resolución — PostgreSQL no disponible"
+        summary = f"No se pudo conectar a la base de datos (`{r['status']}`). Requiere atención manual."
+
+    rows = [f"| Estado | `{r['status']}` |"]
+    if r.get("connections") is not None:
+        rows.append(f"| Conexiones activas | `{r['connections']}` / `{r['max_connections']}` |")
+    if r.get("db_size_mb") is not None:
+        rows.append(f"| Tamaño BD | `{r['db_size_mb']} MB` |")
     if r.get("error"):
         rows.append(f"| Error | `{r['error'][:120]}` |")
 

--- a/Frontend/src/components/AgentReasoningPanel.jsx
+++ b/Frontend/src/components/AgentReasoningPanel.jsx
@@ -544,15 +544,19 @@ function AnalyzingPlaceholder({ phase }) {
 
 // ── Componente principal ─────────────────────────────────────────────────────
 
-export default function AgentReasoningPanel({ reasoning, status }) {
+export default function AgentReasoningPanel({ reasoning, status, fullHeight = false }) {
   const parsed = useMemo(() => parseReasoning(reasoning), [reasoning])
 
   const isThinking = status === 'detected' || status === 'investigating'
 
+  const wrapClass = fullHeight
+    ? 'h-full overflow-y-auto space-y-4'
+    : 'space-y-4'
+
   // 1. Aún no hay nada escrito → skeleton + pasos del pipeline
   if (!reasoning || reasoning.trim() === '') {
     return (
-      <div className="space-y-3">
+      <div className={fullHeight ? 'h-full overflow-y-auto space-y-3' : 'space-y-3'}>
         <Timeline status={status} />
         <AnalyzingPlaceholder phase={status} />
       </div>
@@ -568,7 +572,7 @@ export default function AgentReasoningPanel({ reasoning, status }) {
   const stillInvestigating = isThinking && bodySections.length === 0
 
   return (
-    <div className="space-y-4">
+    <div className={wrapClass}>
       <AgentHeader
         agentName={parsed.agentName}
         incidentType={parsed.incidentType}
@@ -585,7 +589,6 @@ export default function AgentReasoningPanel({ reasoning, status }) {
           {bodySections.map((s, i) => (
             <SectionCard key={`${s.title}-${i}`} title={s.title} body={s.body} index={i} />
           ))}
-          {/* Cursor parpadeante si el agente aún está activo pero ya mostró contenido */}
           {isThinking && (
             <div className="flex items-center gap-2 pl-4 text-slate-500 text-xs">
               <ThinkingDots />

--- a/Frontend/src/components/AgentReasoningPanel.jsx
+++ b/Frontend/src/components/AgentReasoningPanel.jsx
@@ -298,13 +298,14 @@ function AgentHeader({ agentName, incidentType, tools, similarCount, status }) {
 }
 
 function Timeline({ status }) {
-  // Status flow: detected → investigating → analyzed → awaiting_approval → executing_solution → (resolved | failed)
+  // Status flow: detected → investigating → analyzed → awaiting_approval → executing_solution → verifying → (resolved | failed)
   const steps = [
     { key: 'detected', label: 'Detectado' },
     { key: 'investigating', label: 'Investigando' },
     { key: 'analyzed', label: 'Analizado' },
     { key: 'awaiting_approval', label: 'Esperando aprobación' },
     { key: 'executing_solution', label: 'Ejecutando solución' },
+    { key: 'verifying', label: 'Verificando' },
   ]
   const currentIdx = steps.findIndex((step) => step.key === status)
   const reachedTerminal = status === 'resolved' || status === 'failed'

--- a/Frontend/src/components/AgentReasoningPanel.jsx
+++ b/Frontend/src/components/AgentReasoningPanel.jsx
@@ -25,6 +25,14 @@ const AGENT_STYLES = {
     glow: 'from-sky-500/20 to-blue-600/10',
     badge: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
   },
+  podman: {
+    label: 'Podman Agent',
+    subtitle: 'Especialista en contenedores Podman',
+    letter: 'P',
+    ring: 'ring-purple-500/40',
+    glow: 'from-purple-500/20 to-violet-600/10',
+    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+  },
   kubernetes: {
     label: 'Kubernetes Agent',
     subtitle: 'Especialista en workloads Kubernetes',

--- a/Frontend/src/components/AgentReasoningPanel.jsx
+++ b/Frontend/src/components/AgentReasoningPanel.jsx
@@ -290,21 +290,22 @@ function AgentHeader({ agentName, incidentType, tools, similarCount, status }) {
 }
 
 function Timeline({ status }) {
-  // Status flow: detected → investigating → analyzed → resolved
+  // Status flow: detected → investigating → analyzed → awaiting_approval → executing_solution → (resolved | failed)
   const steps = [
     { key: 'detected', label: 'Detectado' },
     { key: 'investigating', label: 'Investigando' },
     { key: 'analyzed', label: 'Analizado' },
-    { key: 'resolved', label: 'Resuelto' },
+    { key: 'awaiting_approval', label: 'Esperando aprobación' },
+    { key: 'executing_solution', label: 'Ejecutando solución' },
   ]
-  const order = ['detected', 'investigating', 'analyzed', 'resolved']
-  const currentIdx = order.indexOf(status)
+  const currentIdx = steps.findIndex((step) => step.key === status)
+  const reachedTerminal = status === 'resolved' || status === 'failed'
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1 flex-wrap">
       {steps.map((step, i) => {
-        const isDone = i < currentIdx
-        const isCurrent = i === currentIdx
+        const isDone = reachedTerminal ? true : i < currentIdx
+        const isCurrent = !reachedTerminal && i === currentIdx
         return (
           <div key={step.key} className="flex items-center gap-1">
             <div
@@ -331,6 +332,34 @@ function Timeline({ status }) {
           </div>
         )
       })}
+
+      <div className="w-2 h-px bg-slate-800" />
+
+      <div
+        className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[10px] font-medium transition-colors ${
+          status === 'resolved'
+            ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+            : 'bg-slate-900 border-slate-800 text-slate-600'
+        }`}
+      >
+        <span
+          className={`w-1.5 h-1.5 rounded-full ${status === 'resolved' ? 'bg-emerald-400' : 'bg-slate-700'}`}
+        />
+        Resuelto
+      </div>
+
+      <div
+        className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[10px] font-medium transition-colors ${
+          status === 'failed'
+            ? 'bg-red-500/10 border-red-500/30 text-red-300'
+            : 'bg-slate-900 border-slate-800 text-slate-600'
+        }`}
+      >
+        <span
+          className={`w-1.5 h-1.5 rounded-full ${status === 'failed' ? 'bg-red-400' : 'bg-slate-700'}`}
+        />
+        Falló
+      </div>
     </div>
   )
 }

--- a/Frontend/src/components/ApprovalModal.jsx
+++ b/Frontend/src/components/ApprovalModal.jsx
@@ -1,0 +1,156 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+const RISK_BY_TYPE = {
+  oom:                 { level: 'Alto',  color: 'text-orange-400', bg: 'bg-orange-500/10 border-orange-500/25' },
+  app_crash:           { level: 'Alto',  color: 'text-orange-400', bg: 'bg-orange-500/10 border-orange-500/25' },
+  restart_loop:        { level: 'Alto',  color: 'text-orange-400', bg: 'bg-orange-500/10 border-orange-500/25' },
+  config_error:        { level: 'Medio', color: 'text-yellow-400', bg: 'bg-yellow-500/10 border-yellow-500/25' },
+  dependency_failure:  { level: 'Medio', color: 'text-yellow-400', bg: 'bg-yellow-500/10 border-yellow-500/25' },
+  network_issue:       { level: 'Medio', color: 'text-yellow-400', bg: 'bg-yellow-500/10 border-yellow-500/25' },
+}
+
+function getRisk(incidentType, command) {
+  if (command?.includes('logs')) return { level: 'Bajo', color: 'text-emerald-400', bg: 'bg-emerald-500/10 border-emerald-500/25' }
+  return RISK_BY_TYPE[incidentType] || { level: 'Medio', color: 'text-yellow-400', bg: 'bg-yellow-500/10 border-yellow-500/25' }
+}
+
+async function callApi(path, body) {
+  const { data: { session } } = await supabase.auth.getSession()
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json().catch(() => null)
+  if (!res.ok) throw new Error(data?.detail || `Error ${res.status}`)
+  return data
+}
+
+export default function ApprovalModal({ incident, onApprove, onClose }) {
+  const [comment, setComment] = useState('')
+  const [loading, setLoading] = useState(null) // 'approve' | 'reject' | 'postpone'
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const risk = getRisk(incident.incident_type, incident.proposed_action)
+
+  const handle = async (action) => {
+    setLoading(action)
+    setError(null)
+    try {
+      if (action === 'approve') {
+        await onApprove(comment)
+      } else {
+        await callApi(`/api/incidents/${incident.id}/${action}`, { comment })
+      }
+      onClose()
+    } catch (e) {
+      setError(e.message)
+      setLoading(null)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="relative w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-100">Aprobar acción de alto riesgo</h2>
+            <p className="text-xs text-slate-400 mt-0.5">Revisa los detalles antes de ejecutar</p>
+          </div>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-300 transition-colors text-lg leading-none">×</button>
+        </div>
+
+        <div className="px-5 py-4 space-y-4">
+          {/* Detalles del incidente */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-slate-950 rounded-lg p-3">
+              <p className="text-xs text-slate-500 mb-1">Servicio afectado</p>
+              <p className="text-xs text-slate-200 font-mono truncate">{incident.target}</p>
+            </div>
+            <div className="bg-slate-950 rounded-lg p-3">
+              <p className="text-xs text-slate-500 mb-1">Tipo de incidente</p>
+              <p className="text-xs text-slate-200">{incident.incident_type || '—'}</p>
+            </div>
+          </div>
+
+          {/* Nivel de riesgo */}
+          <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border ${risk.bg}`}>
+            <span className="text-xs text-slate-400">Nivel de riesgo:</span>
+            <span className={`text-xs font-semibold ${risk.color}`}>{risk.level}</span>
+            {risk.level === 'Alto' && (
+              <span className="text-xs text-slate-400 ml-1">— El reinicio interrumpirá el servicio brevemente.</span>
+            )}
+          </div>
+
+          {/* Comando */}
+          <div>
+            <p className="text-xs text-slate-500 mb-1.5">Comando a ejecutar</p>
+            <pre className="bg-slate-950 border border-slate-800 rounded-lg p-3 text-xs text-sky-300 font-mono">
+              {incident.proposed_action}
+            </pre>
+          </div>
+
+          {/* Comentario */}
+          <div>
+            <label className="text-xs text-slate-500 block mb-1.5">
+              Comentario <span className="text-slate-600">(opcional)</span>
+            </label>
+            <textarea
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder="Ej: Aprobado tras verificar que no hay tráfico activo..."
+              rows={2}
+              className="w-full bg-slate-950 border border-slate-700 rounded-lg px-3 py-2 text-xs text-slate-200 placeholder-slate-600 focus:outline-none focus:border-slate-500 resize-none"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/25 rounded-lg px-3 py-2">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Acciones */}
+        <div className="flex gap-2 px-5 pb-5">
+          <button
+            onClick={() => handle('approve')}
+            disabled={!!loading}
+            className="flex-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg px-4 py-2 text-xs font-medium transition-colors"
+          >
+            {loading === 'approve' ? 'Aprobando...' : '✓ Aprobar'}
+          </button>
+          <button
+            onClick={() => handle('postpone')}
+            disabled={!!loading}
+            className="flex-1 bg-slate-700 hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed text-slate-200 rounded-lg px-4 py-2 text-xs font-medium transition-colors"
+          >
+            {loading === 'postpone' ? 'Posponiendo...' : '⏸ Posponer'}
+          </button>
+          <button
+            onClick={() => handle('reject')}
+            disabled={!!loading}
+            className="flex-1 bg-red-900/40 hover:bg-red-900/70 disabled:opacity-50 disabled:cursor-not-allowed text-red-400 border border-red-800/50 rounded-lg px-4 py-2 text-xs font-medium transition-colors"
+          >
+            {loading === 'reject' ? 'Rechazando...' : '✗ Rechazar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/Frontend/src/components/IncidentTimeline.jsx
+++ b/Frontend/src/components/IncidentTimeline.jsx
@@ -1,0 +1,252 @@
+import { useMemo } from 'react'
+
+// Orden canónico del ciclo de vida de un incidente
+const STATUS_ORDER = [
+  'detected',
+  'investigating',
+  'analyzed',
+  'awaiting_approval',
+  'executing_solution',
+  'verifying',
+  'resolved',
+  'failed',
+]
+
+function statusIndex(status) {
+  const idx = STATUS_ORDER.indexOf(status)
+  return idx === -1 ? 0 : idx
+}
+
+function fmt(dateStr) {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleString('es-CO', {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+}
+
+function extractToolsFromReasoning(reasoning) {
+  if (!reasoning) return []
+  const match = reasoning.match(/Tools invocadas:\s*([^\n.]+)/i)
+  if (!match) return []
+  return match[1]
+    .split(/[,—]/)
+    .map((t) => t.replace(/`/g, '').trim())
+    .filter((t) => t && t !== 'ninguna')
+}
+
+function buildEvents(incident) {
+  const current = statusIndex(incident.status)
+  const isTerminal = incident.status === 'resolved' || incident.status === 'failed'
+  const tools = extractToolsFromReasoning(incident.agent_reasoning)
+
+  const reached = (s) => {
+    if (isTerminal) return true
+    return statusIndex(s) <= current
+  }
+  const isCurrent = (s) => !isTerminal && incident.status === s
+
+  const events = []
+
+  // 1. Detectado
+  events.push({
+    key: 'detected',
+    label: 'Detectado',
+    timestamp: fmt(incident.created_at),
+    description: `Incidente creado · severidad ${incident.severity}${incident.server_name ? ` · ${incident.server_name}` : ''}`,
+    done: reached('detected'),
+    active: isCurrent('detected'),
+    variant: 'blue',
+  })
+
+  // 2. Clasificando
+  events.push({
+    key: 'investigating',
+    label: 'Clasificando',
+    timestamp: null,
+    description: incident.incident_type
+      ? `Tipo detectado: ${incident.incident_type}`
+      : 'El agente está analizando el título, severidad y logs…',
+    done: reached('investigating'),
+    active: isCurrent('investigating'),
+    variant: 'purple',
+  })
+
+  // 3. Investigado
+  events.push({
+    key: 'analyzed',
+    label: 'Investigado',
+    timestamp: null,
+    description: tools.length > 0
+      ? `Tools usadas: ${tools.map((t) => `\`${t}\``).join(', ')}`
+      : incident.incident_type
+        ? 'Análisis de causa raíz completado'
+        : 'Pendiente de análisis',
+    done: reached('analyzed'),
+    active: isCurrent('analyzed'),
+    variant: 'amber',
+  })
+
+  // 4. Esperando aprobación (solo si aplica)
+  if (incident.proposed_action || statusIndex(incident.status) >= statusIndex('awaiting_approval')) {
+    events.push({
+      key: 'awaiting_approval',
+      label: 'Esperando aprobación',
+      timestamp: null,
+      description: incident.proposed_action
+        ? `Acción propuesta: \`${incident.proposed_action}\``
+        : 'Acción pendiente de revisión',
+      done: reached('awaiting_approval'),
+      active: isCurrent('awaiting_approval'),
+      variant: 'cyan',
+    })
+  }
+
+  // 5. Ejecutando (solo si pasó por esa etapa)
+  if (incident.executed_at || statusIndex(incident.status) >= statusIndex('executing_solution')) {
+    events.push({
+      key: 'executing_solution',
+      label: 'Acción ejecutada',
+      timestamp: fmt(incident.executed_at),
+      description: incident.proposed_action
+        ? `\`${incident.proposed_action}\``
+        : 'Comando ejecutado',
+      done: reached('executing_solution'),
+      active: isCurrent('executing_solution'),
+      variant: 'indigo',
+    })
+  }
+
+  // 6. Verificando (solo si pasó por esa etapa)
+  if (statusIndex(incident.status) >= statusIndex('verifying')) {
+    events.push({
+      key: 'verifying',
+      label: 'Verificando servicio',
+      timestamp: null,
+      description: 'El agente comprueba si el contenedor volvió a estado running',
+      done: reached('verifying'),
+      active: isCurrent('verifying'),
+      variant: 'teal',
+    })
+  }
+
+  // 7. Terminal: resuelto o falló
+  if (incident.status === 'resolved') {
+    events.push({
+      key: 'resolved',
+      label: 'Resuelto',
+      timestamp: fmt(incident.resolved_at),
+      description: 'Servicio verificado y recuperado correctamente',
+      done: true,
+      active: false,
+      variant: 'emerald',
+    })
+  } else if (incident.status === 'failed') {
+    events.push({
+      key: 'failed',
+      label: 'Falló',
+      timestamp: null,
+      description: incident.action_error
+        ? incident.action_error.replace(/^\[RECHAZADO\]\s*|^\[POSPUESTO\]\s*/i, '').slice(0, 120)
+        : 'La acción no pudo completarse',
+      done: true,
+      active: false,
+      variant: 'red',
+    })
+  }
+
+  return events
+}
+
+const VARIANT_STYLES = {
+  blue:    { dot: 'bg-blue-400',    ring: 'ring-blue-500/30',    label: 'text-blue-300',    line: 'bg-blue-500/20' },
+  purple:  { dot: 'bg-purple-400',  ring: 'ring-purple-500/30',  label: 'text-purple-300',  line: 'bg-purple-500/20' },
+  amber:   { dot: 'bg-amber-400',   ring: 'ring-amber-500/30',   label: 'text-amber-300',   line: 'bg-amber-500/20' },
+  cyan:    { dot: 'bg-cyan-400',    ring: 'ring-cyan-500/30',    label: 'text-cyan-300',    line: 'bg-cyan-500/20' },
+  indigo:  { dot: 'bg-indigo-400',  ring: 'ring-indigo-500/30',  label: 'text-indigo-300',  line: 'bg-indigo-500/20' },
+  teal:    { dot: 'bg-teal-400',    ring: 'ring-teal-500/30',    label: 'text-teal-300',    line: 'bg-teal-500/20' },
+  emerald: { dot: 'bg-emerald-400', ring: 'ring-emerald-500/30', label: 'text-emerald-300', line: 'bg-emerald-500/20' },
+  red:     { dot: 'bg-red-400',     ring: 'ring-red-500/30',     label: 'text-red-300',     line: 'bg-red-500/20' },
+}
+
+function TimelineEvent({ event, isLast }) {
+  const v = VARIANT_STYLES[event.variant] || VARIANT_STYLES.blue
+  const pending = !event.done && !event.active
+
+  // Split description on backtick blocks for monospace rendering
+  function renderDesc(text) {
+    if (!text) return null
+    const parts = text.split(/(`[^`]+`)/)
+    return parts.map((part, i) =>
+      part.startsWith('`') && part.endsWith('`')
+        ? <code key={i} className="text-[10px] font-mono bg-slate-800 px-1 py-0.5 rounded text-slate-300">{part.slice(1, -1)}</code>
+        : <span key={i}>{part}</span>
+    )
+  }
+
+  return (
+    <div className="flex gap-3">
+      {/* Dot + line */}
+      <div className="flex flex-col items-center">
+        <div
+          className={`w-7 h-7 rounded-full flex items-center justify-center ring-2 shrink-0 transition-all ${
+            pending
+              ? 'bg-slate-900 ring-slate-800'
+              : event.active
+                ? `${v.dot.replace('bg-', 'bg-').replace('-400', '-500/20')} ${v.ring} ring-2`
+                : `${v.dot.replace('-400', '-500/15')} ${v.ring}`
+          }`}
+        >
+          {event.done && !event.active ? (
+            <svg className={`w-3.5 h-3.5 ${pending ? 'text-slate-700' : v.label}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          ) : event.active ? (
+            <span className={`w-2.5 h-2.5 rounded-full ${v.dot} animate-pulse`} />
+          ) : (
+            <span className="w-2 h-2 rounded-full bg-slate-700" />
+          )}
+        </div>
+        {!isLast && (
+          <div className={`w-px flex-1 mt-1 ${event.done ? v.line : 'bg-slate-800'}`} style={{ minHeight: '20px' }} />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className={`pb-5 min-w-0 flex-1 ${isLast ? 'pb-0' : ''}`}>
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-xs font-semibold ${pending ? 'text-slate-600' : v.label}`}>
+            {event.label}
+          </span>
+          {event.timestamp && (
+            <span className="text-[10px] text-slate-600 font-mono">{event.timestamp}</span>
+          )}
+          {event.active && (
+            <span className={`text-[10px] px-1.5 py-0.5 rounded-full border ${v.ring} ${v.label} bg-slate-900`}>
+              en curso
+            </span>
+          )}
+        </div>
+        {event.description && (
+          <p className={`text-[11px] mt-0.5 leading-relaxed ${pending ? 'text-slate-700' : 'text-slate-400'}`}>
+            {renderDesc(event.description)}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function IncidentTimeline({ incident }) {
+  const events = useMemo(() => buildEvents(incident), [incident])
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-lg p-4">
+      <div className="space-y-0">
+        {events.map((event, i) => (
+          <TimelineEvent key={event.key} event={event} isLast={i === events.length - 1} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/Frontend/src/components/MetricsPanel.jsx
+++ b/Frontend/src/components/MetricsPanel.jsx
@@ -1,0 +1,191 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+
+async function fetchMetrics(incidentId) {
+  const { data: { session } } = await supabase.auth.getSession()
+  const token = session?.access_token
+  const res = await fetch(
+    `${import.meta.env.VITE_API_URL || 'http://localhost:8000'}/api/incidents/${incidentId}/metrics`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function fmt(val, unit = '', decimals = 1) {
+  if (val === null || val === undefined) return '—'
+  return `${Number(val).toFixed(decimals)}${unit}`
+}
+
+function UsageBar({ percent, warnAt = 75, critAt = 90 }) {
+  if (percent === null || percent === undefined) return null
+  const color =
+    percent >= critAt ? 'bg-red-500' :
+    percent >= warnAt ? 'bg-amber-500' :
+    'bg-emerald-500'
+  return (
+    <div className="mt-1.5 h-1.5 rounded-full bg-slate-800 overflow-hidden">
+      <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${Math.min(percent, 100)}%` }} />
+    </div>
+  )
+}
+
+function MetricTile({ label, value, sub, percent, warnAt, critAt, highlight }) {
+  const valueColor =
+    highlight === 'bad'    ? 'text-red-300' :
+    highlight === 'warn'   ? 'text-amber-300' :
+    highlight === 'good'   ? 'text-emerald-300' :
+    'text-slate-200'
+
+  return (
+    <div className="bg-slate-950 border border-slate-800 rounded-lg p-3">
+      <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{label}</p>
+      <p className={`text-sm font-semibold font-mono ${valueColor}`}>{value}</p>
+      {sub  && <p className="text-[10px] text-slate-600 mt-0.5">{sub}</p>}
+      {percent !== undefined && (
+        <UsageBar percent={percent} warnAt={warnAt} critAt={critAt} />
+      )}
+    </div>
+  )
+}
+
+function ContainerMetrics({ m }) {
+  const memHighlight =
+    m.mem_percent >= 90 ? 'bad' :
+    m.mem_percent >= 75 ? 'warn' : null
+
+  const cpuHighlight =
+    m.cpu_percent >= 90 ? 'bad' :
+    m.cpu_percent >= 60 ? 'warn' : null
+
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+      <MetricTile
+        label="Memoria"
+        value={fmt(m.mem_usage_mb, ' MB', 0)}
+        sub={m.mem_limit_mb ? `límite ${fmt(m.mem_limit_mb, ' MB', 0)} · ${fmt(m.mem_percent, '%')}` : 'sin límite'}
+        percent={m.mem_percent}
+        warnAt={75} critAt={90}
+        highlight={memHighlight}
+      />
+      <MetricTile
+        label="CPU"
+        value={fmt(m.cpu_percent, '%')}
+        highlight={cpuHighlight}
+      />
+      <MetricTile
+        label="Red entrada"
+        value={m.net_in_kbps !== null ? fmt(m.net_in_kbps, ' KB/s') : '—'}
+      />
+      <MetricTile
+        label="Red salida"
+        value={m.net_out_kbps !== null ? fmt(m.net_out_kbps, ' KB/s') : '—'}
+      />
+      <MetricTile
+        label="Reinicios (1h)"
+        value={m.restarts_1h !== null ? String(m.restarts_1h) : '—'}
+        highlight={m.restarts_1h >= 3 ? 'bad' : m.restarts_1h >= 1 ? 'warn' : null}
+      />
+    </div>
+  )
+}
+
+function PostgresMetrics({ m }) {
+  const connHighlight =
+    m.conn_percent >= 90 ? 'bad' :
+    m.conn_percent >= 70 ? 'warn' : null
+
+  const cacheHighlight =
+    m.cache_hit_percent < 80 ? 'bad' :
+    m.cache_hit_percent < 90 ? 'warn' :
+    'good'
+
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+      <MetricTile
+        label="Conexiones"
+        value={m.connections !== null ? String(m.connections) : '—'}
+        sub={m.max_connections ? `máx ${m.max_connections} · ${fmt(m.conn_percent, '%')}` : null}
+        percent={m.conn_percent}
+        warnAt={70} critAt={90}
+        highlight={connHighlight}
+      />
+      <MetricTile
+        label="Tamaño BD"
+        value={fmt(m.db_size_mb, ' MB', 0)}
+      />
+      <MetricTile
+        label="Cache hit ratio"
+        value={fmt(m.cache_hit_percent, '%')}
+        highlight={cacheHighlight}
+      />
+      <MetricTile
+        label="Deadlocks/min"
+        value={fmt(m.deadlocks_per_min, '', 2)}
+        highlight={m.deadlocks_per_min > 0 ? 'warn' : null}
+      />
+      <MetricTile
+        label="Transacción más larga"
+        value={m.longest_tx_sec !== null ? fmt(m.longest_tx_sec, 's') : '—'}
+        highlight={m.longest_tx_sec > 300 ? 'bad' : m.longest_tx_sec > 60 ? 'warn' : null}
+      />
+    </div>
+  )
+}
+
+export default function MetricsPanel({ incidentId }) {
+  const [metrics, setMetrics] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchMetrics(incidentId)
+      .then((data) => { if (!cancelled) { setMetrics(data); setLoading(false) } })
+      .catch((e)   => { if (!cancelled) { setError(e.message); setLoading(false) } })
+    return () => { cancelled = true }
+  }, [incidentId])
+
+  const allNull = metrics && Object.entries(metrics)
+    .filter(([k]) => k !== 'type')
+    .every(([, v]) => v === null)
+
+  if (loading) {
+    return (
+      <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 flex items-center gap-2 text-xs text-slate-500">
+        <span className="w-3 h-3 rounded-full border-2 border-slate-600 border-t-slate-400 animate-spin" />
+        Consultando Prometheus…
+      </div>
+    )
+  }
+
+  if (error || allNull) {
+    return (
+      <div className="bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <p className="text-xs text-slate-600">
+          Métricas no disponibles — Prometheus sin datos para este target.
+        </p>
+        <p className="text-[10px] text-slate-700 mt-1">
+          El stack de monitoreo puede estar apagado o el contenedor ya no existe.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-slate-500 uppercase tracking-wider">
+          {metrics.type === 'postgres' ? 'PostgreSQL' : 'Contenedor'} · en vivo
+        </span>
+        <span className="text-[10px] text-slate-700">via Prometheus</span>
+      </div>
+      {metrics.type === 'postgres'
+        ? <PostgresMetrics m={metrics} />
+        : <ContainerMetrics m={metrics} />
+      }
+    </div>
+  )
+}

--- a/Frontend/src/components/RunbookViewer.jsx
+++ b/Frontend/src/components/RunbookViewer.jsx
@@ -1,0 +1,102 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '../lib/supabase'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+async function fetchRunbooks(incidentId, q) {
+  const { data: { session } } = await supabase.auth.getSession()
+  const url = new URL(`${API_URL}/api/incidents/${incidentId}/runbooks`)
+  if (q) url.searchParams.set('q', q)
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${session.access_token}` },
+  })
+  if (!res.ok) throw new Error('Error al cargar runbooks')
+  return res.json()
+}
+
+export default function RunbookViewer({ incidentId }) {
+  const [runbooks, setRunbooks] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [search, setSearch] = useState('')
+  const [expanded, setExpanded] = useState(null)
+
+  const load = useCallback(async (q = '') => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fetchRunbooks(incidentId, q)
+      setRunbooks(data)
+      setExpanded(data.length > 0 ? 0 : null)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [incidentId])
+
+  useEffect(() => { load() }, [load])
+
+  const handleSearch = (e) => {
+    e.preventDefault()
+    load(search.trim())
+  }
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={handleSearch} className="flex gap-2">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Buscar en runbooks..."
+          className="flex-1 bg-slate-900 border border-slate-700 rounded-md px-3 py-1.5 text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:border-slate-500"
+        />
+        <button
+          type="submit"
+          className="px-3 py-1.5 bg-slate-700 hover:bg-slate-600 text-slate-200 rounded-md text-xs transition-colors"
+        >
+          Buscar
+        </button>
+      </form>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-xs text-slate-500 py-2">
+          <span className="w-3 h-3 rounded-full border-2 border-slate-600 border-t-slate-400 animate-spin" />
+          Buscando runbooks relevantes...
+        </div>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && runbooks.length === 0 && (
+        <p className="text-xs text-slate-500 py-2">No se encontraron runbooks para este incidente.</p>
+      )}
+
+      <div className="space-y-2">
+        {runbooks.map((rb, i) => (
+          <div key={i} className="border border-slate-800 rounded-lg overflow-hidden">
+            <button
+              onClick={() => setExpanded(expanded === i ? null : i)}
+              className="w-full flex items-center justify-between px-4 py-2.5 bg-slate-900 hover:bg-slate-800 transition-colors text-left"
+            >
+              <span className="text-xs font-medium text-slate-200 truncate pr-4">{rb.title}</span>
+              <span className="text-slate-500 text-xs shrink-0">
+                {expanded === i ? '▲' : '▼'}
+              </span>
+            </button>
+            {expanded === i && (
+              <pre className="px-4 py-3 text-xs text-slate-300 font-mono whitespace-pre-wrap bg-slate-950 overflow-x-auto max-h-72 overflow-y-auto leading-relaxed">
+                {rb.content}
+              </pre>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/Frontend/src/components/SimilarIncidentsCard.jsx
+++ b/Frontend/src/components/SimilarIncidentsCard.jsx
@@ -1,0 +1,119 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+const SEVERITY_COLORS = {
+  critical: 'text-red-400',
+  high: 'text-orange-400',
+  medium: 'text-yellow-400',
+  low: 'text-slate-400',
+}
+
+function timeAgo(isoString) {
+  if (!isoString) return '—'
+  const diff = Date.now() - new Date(isoString).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 60) return `hace ${mins}m`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `hace ${hrs}h`
+  return `hace ${Math.floor(hrs / 24)}d`
+}
+
+export default function SimilarIncidentsCard({ incidentId, onApplySolution }) {
+  const [similar, setSimilar] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        const res = await fetch(`${API_URL}/api/incidents/${incidentId}/similar`, {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        })
+        if (!res.ok) throw new Error('Error al cargar incidentes similares')
+        const data = await res.json()
+        if (!cancelled) setSimilar(data)
+      } catch (e) {
+        if (!cancelled) setError(e.message)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [incidentId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-slate-500 py-2">
+        <span className="w-3 h-3 rounded-full border-2 border-slate-600 border-t-slate-400 animate-spin" />
+        Buscando incidentes similares...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">
+        {error}
+      </p>
+    )
+  }
+
+  if (similar.length === 0) {
+    return (
+      <p className="text-xs text-slate-500 py-2">
+        No hay incidentes similares en el historial todavía.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {similar.map((item) => {
+        const meta = item.metadata || {}
+        const tools = meta.tools_used ? meta.tools_used.split(',').filter(Boolean) : []
+        return (
+          <div key={item.id} className="bg-slate-900 border border-slate-800 rounded-lg p-3 space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-xs font-medium text-slate-200 leading-snug">{meta.title || 'Incidente anterior'}</p>
+              <span className={`text-xs shrink-0 ${SEVERITY_COLORS[meta.severity] || 'text-slate-400'}`}>
+                {meta.severity || '—'}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
+              <span>Tipo: <span className="text-slate-400">{meta.incident_type || '—'}</span></span>
+              <span>Target: <span className="text-slate-400 font-mono">{meta.target || '—'}</span></span>
+              <span>{timeAgo(meta.stored_at)}</span>
+            </div>
+
+            {tools.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {tools.map((t) => (
+                  <span key={t} className="px-1.5 py-0.5 rounded bg-slate-800 text-slate-400 text-xs font-mono">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {onApplySolution && meta.proposed_action && (
+              <button
+                onClick={() => onApplySolution(item)}
+                className="text-xs text-sky-400 hover:text-sky-300 transition-colors"
+              >
+                Aplicar misma solución →
+              </button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -387,118 +387,129 @@ export default function Dashboard() {
                 <RuntimeBadge runtime={selected.container_runtime} sourceType={selected.source_type} />
               </div>
 
-              <div id="incident-logs-section">
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
-                  Logs del contenedor
-                </p>
-                {selected.logs ? (
-                  <pre className="bg-slate-900 border border-slate-800 rounded-lg p-4 text-xs text-slate-300 font-mono overflow-x-auto whitespace-pre-wrap max-h-[30rem] overflow-y-auto leading-relaxed">
-                    {selected.logs}
-                  </pre>
-                ) : (
-                  <div className="bg-slate-900 border border-slate-800 rounded-lg p-4">
-                    <p className="text-xs text-slate-600">Sin logs disponibles para este incidente</p>
-                  </div>
-                )}
-              </div>
-
-              {(selected.agent_reasoning ||
-                selected.status === 'investigating' ||
-                selected.status === 'detected') && (
-                <div>
-                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
-                    Razonamiento del agente
-                  </p>
-                  <AgentReasoningPanel
-                    reasoning={selected.agent_reasoning}
-                    status={selected.status}
-                  />
-                </div>
-              )}
-
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
-                  Solución propuesta
-                </p>
-
-                <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-3">
-                  <div>
-                    <p className="text-xs text-slate-500 mb-1">Comando sugerido</p>
-                    <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-sky-300 font-mono overflow-x-auto whitespace-pre-wrap">
-                      {selected.proposed_action || 'Sin acción propuesta automática'}
-                    </pre>
+              {/* Layout: análisis (izq) + acciones/resultados (der sticky) */}
+              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-start">
+                {/* Columna izquierda: evidencia + análisis del agente */}
+                <div className="space-y-5 min-w-0">
+                  <div id="incident-logs-section">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                      Logs del contenedor
+                    </p>
+                    {selected.logs ? (
+                      <pre className="bg-slate-900 border border-slate-800 rounded-lg p-4 text-xs text-slate-300 font-mono overflow-x-auto whitespace-pre-wrap max-h-[30rem] overflow-y-auto leading-relaxed">
+                        {selected.logs}
+                      </pre>
+                    ) : (
+                      <div className="bg-slate-900 border border-slate-800 rounded-lg p-4">
+                        <p className="text-xs text-slate-600">Sin logs disponibles para este incidente</p>
+                      </div>
+                    )}
                   </div>
 
-                  <div className="flex items-center gap-2">
-                    <p className="text-xs text-slate-500">Estado actual:</p>
-                    <StatusBadge status={selected.status} />
-                  </div>
-
-                  {selected.status === 'awaiting_approval' && selected.proposed_action && (
-                    <button
-                      onClick={handleApproveAction}
-                      disabled={actionLoading}
-                      className="bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
-                    >
-                      {actionLoading ? 'Aprobando...' : 'Aprobar'}
-                    </button>
-                  )}
-
-                  {selected.status === 'executing_solution' && (
-                    <div className="inline-flex items-center gap-2 text-xs text-indigo-300">
-                      <span className="w-3 h-3 rounded-full border-2 border-indigo-400/40 border-t-indigo-300 animate-spin" />
-                      Ejecutando comando...
+                  {(selected.agent_reasoning ||
+                    selected.status === 'investigating' ||
+                    selected.status === 'detected') && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                        Línea de tiempo y análisis
+                      </p>
+                      <AgentReasoningPanel
+                        reasoning={selected.agent_reasoning}
+                        status={selected.status}
+                      />
                     </div>
                   )}
+                </div>
 
-                  {actionError && selected.status !== 'failed' && (
-                    <p className="text-xs text-red-300 bg-red-500/10 border border-red-500/25 rounded-md px-3 py-2">
-                      {actionError}
-                    </p>
-                  )}
+                {/* Columna derecha: acciones / ejecución (sticky) */}
+                <div className="space-y-3 lg:sticky lg:top-6">
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                    Acción y ejecución
+                  </p>
 
-                  {(selected.action_result || actionResponse?.stdout) && (
+                  <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-3">
                     <div>
-                      <p className="text-xs text-slate-500 mb-1">Resultado (stdout)</p>
-                      <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-emerald-300 font-mono overflow-x-auto whitespace-pre-wrap">
-                        {selected.action_result || actionResponse?.stdout}
+                      <p className="text-xs text-slate-500 mb-1">Comando sugerido</p>
+                      <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-sky-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                        {selected.proposed_action || 'Sin acción propuesta automática'}
                       </pre>
                     </div>
-                  )}
 
-                  {(selected.status === 'failed' || actionResponse?.status === 'failed') && (
-                    <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <p className="text-xs text-slate-500">Estado actual:</p>
+                      <StatusBadge status={selected.status} />
+                    </div>
+
+                    {selected.status === 'awaiting_approval' && selected.proposed_action && (
+                      <button
+                        onClick={handleApproveAction}
+                        disabled={actionLoading}
+                        className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
+                      >
+                        {actionLoading ? 'Aprobando...' : 'Aprobar'}
+                      </button>
+                    )}
+
+                    {selected.status === 'executing_solution' && (
+                      <div className="inline-flex items-center gap-2 text-xs text-indigo-300">
+                        <span className="w-3 h-3 rounded-full border-2 border-indigo-400/40 border-t-indigo-300 animate-spin" />
+                        Ejecutando comando...
+                      </div>
+                    )}
+
+                    {actionError && selected.status !== 'failed' && (
+                      <p className="text-xs text-red-300 bg-red-500/10 border border-red-500/25 rounded-md px-3 py-2">
+                        {actionError}
+                      </p>
+                    )}
+
+                    {(selected.action_result || actionResponse?.stdout) && (
                       <div>
-                        <p className="text-xs text-slate-500 mb-1">Error técnico (stderr)</p>
-                        <pre className="bg-slate-950 border border-red-900/60 rounded-md p-3 text-xs text-red-300 font-mono overflow-x-auto whitespace-pre-wrap">
-                          {selected.action_error || actionResponse?.stderr || actionError || 'Sin detalle técnico'}
+                        <p className="text-xs text-slate-500 mb-1">Resultado (stdout)</p>
+                        <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-emerald-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                          {selected.action_result || actionResponse?.stdout}
                         </pre>
                       </div>
-                      <p className="text-sm text-amber-300">
-                        La ejecución automática falló. Se recomienda revisión manual.
-                      </p>
-                      <p className="text-xs text-slate-400">
-                        Se recomienda revisión manual: revisar logs y ejecutar el comando manualmente si aplica.
-                      </p>
-                      <div className="flex items-center gap-2">
-                        {selected.proposed_action && (
+                    )}
+
+                    {(selected.status === 'failed' || actionResponse?.status === 'failed') && (
+                      <div className="space-y-2">
+                        <div>
+                          <p className="text-xs text-slate-500 mb-1">Error técnico (stderr)</p>
+                          <pre className="bg-slate-950 border border-red-900/60 rounded-md p-3 text-xs text-red-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                            {selected.action_error || actionResponse?.stderr || actionError || 'Sin detalle técnico'}
+                          </pre>
+                        </div>
+                        <p className="text-sm text-amber-300">
+                          La ejecución automática falló. Se recomienda revisión manual.
+                        </p>
+                        <p className="text-xs text-slate-400">
+                          Se recomienda revisión manual: revisar logs y ejecutar el comando manualmente si aplica.
+                        </p>
+                        <div className="flex items-center gap-2">
+                          {selected.proposed_action && (
+                            <button
+                              onClick={handleApproveAction}
+                              disabled={actionLoading}
+                              className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors disabled:opacity-50"
+                            >
+                              {actionLoading ? 'Reintentando...' : 'Reintentar'}
+                            </button>
+                          )}
                           <button
-                            onClick={handleApproveAction}
-                            disabled={actionLoading}
-                            className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors disabled:opacity-50"
+                            onClick={() =>
+                              document
+                                .getElementById('incident-logs-section')
+                                ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                            }
+                            className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors"
                           >
-                            {actionLoading ? 'Reintentando...' : 'Reintentar'}
+                            Ver logs
                           </button>
-                        )}
-                        <button
-                          onClick={() => document.getElementById('incident-logs-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
-                          className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors"
-                        >
-                          Ver logs
-                        </button>
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
             </div>

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ import RunbookViewer from '../components/RunbookViewer'
 import SimilarIncidentsCard from '../components/SimilarIncidentsCard'
 import ApprovalModal from '../components/ApprovalModal'
 import IncidentTimeline from '../components/IncidentTimeline'
+import MetricsPanel from '../components/MetricsPanel'
 import { executeIncidentAction } from '../services/incidentActions'
 
 const SEVERITY_CONFIG = {
@@ -408,6 +409,13 @@ export default function Dashboard() {
                       Línea de tiempo
                     </p>
                     <IncidentTimeline incident={selected} />
+                  </div>
+
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                      Métricas del servicio
+                    </p>
+                    <MetricsPanel incidentId={selected.id} />
                   </div>
 
                   <div id="incident-logs-section">

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import { supabase } from '../lib/supabase'
 import { useIncidentNotifications } from '../hooks/useIncidentNotifications'
 import CreateIncidentModal from '../components/CreateIncidentModal'
 import AgentReasoningPanel from '../components/AgentReasoningPanel'
+import { executeIncidentAction } from '../services/incidentActions'
 
 const SEVERITY_CONFIG = {
   critical: { label: 'Crítico', dot: 'bg-red-500', badge: 'bg-red-500/15 text-red-400 border border-red-500/25' },
@@ -17,7 +18,10 @@ const STATUS_CONFIG = {
   detected: { label: 'Detectado', className: 'bg-blue-500/15 text-blue-400' },
   investigating: { label: 'Investigando', className: 'bg-purple-500/15 text-purple-400' },
   analyzed: { label: 'Analizado', className: 'bg-amber-500/15 text-amber-400' },
+  awaiting_approval: { label: 'Esperando aprobación', className: 'bg-cyan-500/15 text-cyan-400' },
+  executing_solution: { label: 'Ejecutando solución', className: 'bg-indigo-500/15 text-indigo-300' },
   resolved: { label: 'Resuelto', className: 'bg-slate-500/15 text-slate-500' },
+  failed: { label: 'Falló', className: 'bg-red-500/15 text-red-400' },
 }
 
 const TYPE_CONFIG = {
@@ -106,6 +110,9 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [actionError, setActionError] = useState(null)
+  const [actionResponse, setActionResponse] = useState(null)
 
   const selectedIncidentId = searchParams.get('incident')
   const selected = incidents.find((incident) => incident.id === selectedIncidentId) || null
@@ -173,6 +180,12 @@ export default function Dashboard() {
     return () => window.clearInterval(timer)
   }, [refreshSnooze])
 
+  useEffect(() => {
+    setActionLoading(false)
+    setActionError(null)
+    setActionResponse(null)
+  }, [selectedIncidentId])
+
   const openIncident = (incident) => {
     setSearchParams({ incident: incident.id }, { replace: true })
   }
@@ -184,6 +197,25 @@ export default function Dashboard() {
   const handleSignOut = async () => {
     await signOut()
     navigate('/login')
+  }
+
+  const handleApproveAction = async () => {
+    if (!selected?.id || !selected?.proposed_action) return
+
+    setActionLoading(true)
+    setActionError(null)
+
+    try {
+      const response = await executeIncidentAction({
+        incidentId: selected.id,
+        command: selected.proposed_action,
+      })
+      setActionResponse(response)
+    } catch (err) {
+      setActionError(err.message)
+    } finally {
+      setActionLoading(false)
+    }
   }
 
   const criticalCount = incidents.filter(
@@ -355,7 +387,7 @@ export default function Dashboard() {
                 <RuntimeBadge runtime={selected.container_runtime} sourceType={selected.source_type} />
               </div>
 
-              <div>
+              <div id="incident-logs-section">
                 <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
                   Logs del contenedor
                 </p>
@@ -383,6 +415,92 @@ export default function Dashboard() {
                   />
                 </div>
               )}
+
+              <div>
+                <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                  Solución propuesta
+                </p>
+
+                <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-3">
+                  <div>
+                    <p className="text-xs text-slate-500 mb-1">Comando sugerido</p>
+                    <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-sky-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                      {selected.proposed_action || 'Sin acción propuesta automática'}
+                    </pre>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <p className="text-xs text-slate-500">Estado actual:</p>
+                    <StatusBadge status={selected.status} />
+                  </div>
+
+                  {selected.status === 'awaiting_approval' && selected.proposed_action && (
+                    <button
+                      onClick={handleApproveAction}
+                      disabled={actionLoading}
+                      className="bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
+                    >
+                      {actionLoading ? 'Aprobando...' : 'Aprobar'}
+                    </button>
+                  )}
+
+                  {selected.status === 'executing_solution' && (
+                    <div className="inline-flex items-center gap-2 text-xs text-indigo-300">
+                      <span className="w-3 h-3 rounded-full border-2 border-indigo-400/40 border-t-indigo-300 animate-spin" />
+                      Ejecutando comando...
+                    </div>
+                  )}
+
+                  {actionError && selected.status !== 'failed' && (
+                    <p className="text-xs text-red-300 bg-red-500/10 border border-red-500/25 rounded-md px-3 py-2">
+                      {actionError}
+                    </p>
+                  )}
+
+                  {(selected.action_result || actionResponse?.stdout) && (
+                    <div>
+                      <p className="text-xs text-slate-500 mb-1">Resultado (stdout)</p>
+                      <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-emerald-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                        {selected.action_result || actionResponse?.stdout}
+                      </pre>
+                    </div>
+                  )}
+
+                  {(selected.status === 'failed' || actionResponse?.status === 'failed') && (
+                    <div className="space-y-2">
+                      <div>
+                        <p className="text-xs text-slate-500 mb-1">Error técnico (stderr)</p>
+                        <pre className="bg-slate-950 border border-red-900/60 rounded-md p-3 text-xs text-red-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                          {selected.action_error || actionResponse?.stderr || actionError || 'Sin detalle técnico'}
+                        </pre>
+                      </div>
+                      <p className="text-sm text-amber-300">
+                        La ejecución automática falló. Se recomienda revisión manual.
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        Se recomienda revisión manual: revisar logs y ejecutar el comando manualmente si aplica.
+                      </p>
+                      <div className="flex items-center gap-2">
+                        {selected.proposed_action && (
+                          <button
+                            onClick={handleApproveAction}
+                            disabled={actionLoading}
+                            className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors disabled:opacity-50"
+                          >
+                            {actionLoading ? 'Reintentando...' : 'Reintentar'}
+                          </button>
+                        )}
+                        <button
+                          onClick={() => document.getElementById('incident-logs-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                          className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors"
+                        >
+                          Ver logs
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
         ) : (

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -109,6 +109,13 @@ function MetaCard({ label, value, mono = false }) {
   )
 }
 
+const DETAIL_TABS = [
+  { id: 'resumen',      label: 'Resumen' },
+  { id: 'evidencia',    label: 'Evidencia' },
+  { id: 'analisis',     label: 'Análisis' },
+  { id: 'conocimiento', label: 'Conocimiento' },
+]
+
 export default function Dashboard() {
   const { user, signOut } = useAuth()
   const navigate = useNavigate()
@@ -121,6 +128,7 @@ export default function Dashboard() {
   const [actionLoading, setActionLoading] = useState(false)
   const [actionError, setActionError] = useState(null)
   const [actionResponse, setActionResponse] = useState(null)
+  const [detailTab, setDetailTab] = useState('resumen')
 
   const selectedIncidentId = searchParams.get('incident')
   const selected = incidents.find((incident) => incident.id === selectedIncidentId) || null
@@ -197,6 +205,7 @@ export default function Dashboard() {
     setActionError(null)
     setActionResponse(null)
     setShowApprovalModal(false)
+    setDetailTab('resumen')
   }, [selectedIncidentId])
 
   const openIncident = (incident) => {
@@ -374,56 +383,208 @@ export default function Dashboard() {
         {/* Panel de detalle */}
         {selected ? (
           <div className="flex-1 flex flex-col overflow-hidden">
-            <div className="px-6 py-3 border-b border-slate-800 flex items-center justify-between gap-4">
-              <h2 className="text-sm font-medium text-slate-200 truncate">{selected.title}</h2>
-              <button
-                onClick={closeIncidentDetail}
-                className="text-slate-600 hover:text-slate-300 text-xl leading-none shrink-0 transition-colors"
-                aria-label="Cerrar detalle"
-              >
-                ×
-              </button>
+
+            {/* Cabecera fija: título + metadatos + badges */}
+            <div className="px-6 pt-4 pb-0 border-b border-slate-800 shrink-0">
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div className="min-w-0">
+                  <h2 className="text-sm font-semibold text-slate-100 leading-snug">{selected.title}</h2>
+                  <p className="text-xs text-slate-500 mt-0.5 font-mono truncate">
+                    {selected.target}{selected.server_name ? ` · ${selected.server_name}` : ''}
+                  </p>
+                </div>
+                <button
+                  onClick={closeIncidentDetail}
+                  className="text-slate-600 hover:text-slate-300 text-xl leading-none shrink-0 transition-colors mt-0.5"
+                  aria-label="Cerrar detalle"
+                >
+                  ×
+                </button>
+              </div>
+
+              {/* Meta grid + badges en fila */}
+              <div className="flex items-center gap-4 mb-3 flex-wrap">
+                <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                  <span className="text-slate-600">Detectado</span>
+                  <span className="text-slate-300">{formatDate(selected.created_at)}</span>
+                </div>
+                {selected.resolved_at && (
+                  <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                    <span className="text-slate-600">Resuelto</span>
+                    <span className="text-slate-300">{formatDate(selected.resolved_at)}</span>
+                  </div>
+                )}
+                <div className="flex items-center gap-2 flex-wrap ml-auto">
+                  <SeverityBadge severity={selected.severity} />
+                  <StatusBadge status={selected.status} />
+                  <IncidentTypeBadge type={selected.incident_type} />
+                  <RuntimeBadge runtime={selected.container_runtime} sourceType={selected.source_type} />
+                </div>
+              </div>
+
+              {/* Tabs */}
+              <div className="flex gap-0 -mb-px">
+                {DETAIL_TABS.map((tab) => {
+                  const isActive = detailTab === tab.id
+                  const showDot =
+                    tab.id === 'resumen' && selected.status === 'awaiting_approval'
+                  return (
+                    <button
+                      key={tab.id}
+                      onClick={() => setDetailTab(tab.id)}
+                      className={`relative px-4 py-2 text-xs font-medium border-b-2 transition-colors ${
+                        isActive
+                          ? 'border-blue-500 text-blue-400'
+                          : 'border-transparent text-slate-500 hover:text-slate-300 hover:border-slate-600'
+                      }`}
+                    >
+                      {tab.label}
+                      {showDot && (
+                        <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-cyan-400" />
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto p-6 space-y-5">
-              <div className="grid grid-cols-2 gap-3">
-                <MetaCard label="Recurso" value={selected.target} mono />
-                <MetaCard label="Servidor" value={selected.server_name} />
-                <MetaCard label="Detectado" value={formatDate(selected.created_at)} />
-                <MetaCard label="Estado" value={STATUS_CONFIG[selected.status]?.label} />
-              </div>
+            {/* Contenido del tab activo */}
+            <div className="flex-1 overflow-y-auto">
 
-              <div className="flex items-center gap-2 flex-wrap">
-                <SeverityBadge severity={selected.severity} />
-                <StatusBadge status={selected.status} />
-                <IncidentTypeBadge type={selected.incident_type} />
-                <RuntimeBadge runtime={selected.container_runtime} sourceType={selected.source_type} />
-              </div>
+              {/* ── Tab: Resumen ────────────────────────────────────────── */}
+              {detailTab === 'resumen' && (
+                <div className="p-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_380px] lg:items-start h-full">
 
-              {/* Layout: análisis (izq) + acciones/resultados (der sticky) */}
-              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-start">
-                {/* Columna izquierda: evidencia + análisis del agente */}
-                <div className="space-y-5 min-w-0">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                  {/* Columna izquierda: timeline */}
+                  <div className="space-y-2 min-w-0">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                       Línea de tiempo
                     </p>
                     <IncidentTimeline incident={selected} />
                   </div>
 
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                  {/* Columna derecha: acción y ejecución */}
+                  <div className="space-y-3">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                      Acción y ejecución
+                    </p>
+
+                    <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-3">
+                      <div>
+                        <p className="text-xs text-slate-500 mb-1">Comando sugerido</p>
+                        <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-sky-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                          {selected.proposed_action || 'Sin acción propuesta automática'}
+                        </pre>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <p className="text-xs text-slate-500">Estado actual:</p>
+                        <StatusBadge status={selected.status} />
+                      </div>
+
+                      {selected.status === 'awaiting_approval' && selected.proposed_action && (
+                        <button
+                          onClick={() => setShowApprovalModal(true)}
+                          className="w-full bg-emerald-600 hover:bg-emerald-500 text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
+                        >
+                          Revisar y aprobar acción
+                        </button>
+                      )}
+
+                      {selected.status === 'executing_solution' && (
+                        <div className="inline-flex items-center gap-2 text-xs text-indigo-300">
+                          <span className="w-3 h-3 rounded-full border-2 border-indigo-400/40 border-t-indigo-300 animate-spin" />
+                          Ejecutando comando...
+                        </div>
+                      )}
+
+                      {selected.status === 'verifying' && (
+                        <div className="bg-teal-500/10 border border-teal-500/25 rounded-md px-3 py-2.5 space-y-1">
+                          <div className="inline-flex items-center gap-2 text-xs text-teal-300">
+                            <span className="w-3 h-3 rounded-full border-2 border-teal-400/40 border-t-teal-300 animate-spin" />
+                            Verificando resolución del servicio...
+                          </div>
+                          <p className="text-xs text-teal-400/60">
+                            El agente está comprobando si el contenedor volvió a estado running.
+                          </p>
+                        </div>
+                      )}
+
+                      {selected.status === 'resolved' && selected.executed_at && (
+                        <div className="inline-flex items-center gap-2 text-xs text-emerald-400">
+                          <span className="w-2 h-2 rounded-full bg-emerald-400" />
+                          Servicio verificado y recuperado
+                        </div>
+                      )}
+
+                      {actionError && selected.status !== 'failed' && (
+                        <p className="text-xs text-red-300 bg-red-500/10 border border-red-500/25 rounded-md px-3 py-2">
+                          {actionError}
+                        </p>
+                      )}
+
+                      {(selected.action_result || actionResponse?.stdout) && (
+                        <div>
+                          <p className="text-xs text-slate-500 mb-1">Resultado (stdout)</p>
+                          <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-emerald-300 font-mono overflow-x-auto whitespace-pre-wrap max-h-48 overflow-y-auto">
+                            {selected.action_result || actionResponse?.stdout}
+                          </pre>
+                        </div>
+                      )}
+
+                      {(selected.status === 'failed' || actionResponse?.status === 'failed') && (
+                        <div className="space-y-2">
+                          <div>
+                            <p className="text-xs text-slate-500 mb-1">Error técnico (stderr)</p>
+                            <pre className="bg-slate-950 border border-red-900/60 rounded-md p-3 text-xs text-red-300 font-mono overflow-x-auto whitespace-pre-wrap max-h-36 overflow-y-auto">
+                              {selected.action_error || actionResponse?.stderr || actionError || 'Sin detalle técnico'}
+                            </pre>
+                          </div>
+                          <p className="text-sm text-amber-300">
+                            La ejecución automática falló. Se recomienda revisión manual.
+                          </p>
+                          <div className="flex items-center gap-2">
+                            {selected.proposed_action && (
+                              <button
+                                onClick={handleApproveAction}
+                                disabled={actionLoading}
+                                className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors disabled:opacity-50"
+                              >
+                                {actionLoading ? 'Reintentando...' : 'Reintentar'}
+                              </button>
+                            )}
+                            <button
+                              onClick={() => setDetailTab('evidencia')}
+                              className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors"
+                            >
+                              Ver logs →
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* ── Tab: Evidencia ──────────────────────────────────────── */}
+              {detailTab === 'evidencia' && (
+                <div className="p-6 grid gap-5 lg:grid-cols-2 lg:items-start">
+                  {/* Métricas */}
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                       Métricas del servicio
                     </p>
                     <MetricsPanel incidentId={selected.id} />
                   </div>
 
-                  <div id="incident-logs-section">
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                  {/* Logs */}
+                  <div className="space-y-2 flex flex-col">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                       Logs del contenedor
                     </p>
                     {selected.logs ? (
-                      <pre className="bg-slate-900 border border-slate-800 rounded-lg p-4 text-xs text-slate-300 font-mono overflow-x-auto whitespace-pre-wrap max-h-[30rem] overflow-y-auto leading-relaxed">
+                      <pre className="flex-1 bg-slate-900 border border-slate-800 rounded-lg p-4 text-xs text-slate-300 font-mono overflow-auto whitespace-pre-wrap leading-relaxed" style={{ maxHeight: 'calc(100vh - 280px)' }}>
                         {selected.logs}
                       </pre>
                     ) : (
@@ -432,145 +593,44 @@ export default function Dashboard() {
                       </div>
                     )}
                   </div>
+                </div>
+              )}
 
-                  {(selected.agent_reasoning ||
-                    selected.status === 'investigating' ||
-                    selected.status === 'detected') && (
-                    <div>
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
-                        Análisis del agente
-                      </p>
-                      <AgentReasoningPanel
-                        reasoning={selected.agent_reasoning}
-                        status={selected.status}
-                      />
-                    </div>
-                  )}
+              {/* ── Tab: Análisis ───────────────────────────────────────── */}
+              {detailTab === 'analisis' && (
+                <div className="p-6 space-y-2 h-full flex flex-col">
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider shrink-0">
+                    Análisis del agente
+                  </p>
+                  <div className="flex-1 min-h-0">
+                    <AgentReasoningPanel
+                      reasoning={selected.agent_reasoning}
+                      status={selected.status}
+                      fullHeight
+                    />
+                  </div>
+                </div>
+              )}
 
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+              {/* ── Tab: Conocimiento ───────────────────────────────────── */}
+              {detailTab === 'conocimiento' && (
+                <div className="p-6 grid gap-5 lg:grid-cols-2 lg:items-start">
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                       Runbooks relevantes
                     </p>
                     <RunbookViewer incidentId={selected.id} />
                   </div>
 
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                       Incidentes similares
                     </p>
                     <SimilarIncidentsCard incidentId={selected.id} />
                   </div>
                 </div>
+              )}
 
-                {/* Columna derecha: acciones / ejecución (sticky) */}
-                <div className="space-y-3 lg:sticky lg:top-6">
-                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
-                    Acción y ejecución
-                  </p>
-
-                  <div className="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-3">
-                    <div>
-                      <p className="text-xs text-slate-500 mb-1">Comando sugerido</p>
-                      <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-sky-300 font-mono overflow-x-auto whitespace-pre-wrap">
-                        {selected.proposed_action || 'Sin acción propuesta automática'}
-                      </pre>
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                      <p className="text-xs text-slate-500">Estado actual:</p>
-                      <StatusBadge status={selected.status} />
-                    </div>
-
-                    {selected.status === 'awaiting_approval' && selected.proposed_action && (
-                      <button
-                        onClick={() => setShowApprovalModal(true)}
-                        className="w-full bg-emerald-600 hover:bg-emerald-500 text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
-                      >
-                        Revisar y aprobar acción
-                      </button>
-                    )}
-
-                    {selected.status === 'executing_solution' && (
-                      <div className="inline-flex items-center gap-2 text-xs text-indigo-300">
-                        <span className="w-3 h-3 rounded-full border-2 border-indigo-400/40 border-t-indigo-300 animate-spin" />
-                        Ejecutando comando...
-                      </div>
-                    )}
-
-                    {selected.status === 'verifying' && (
-                      <div className="bg-teal-500/10 border border-teal-500/25 rounded-md px-3 py-2.5 space-y-1">
-                        <div className="inline-flex items-center gap-2 text-xs text-teal-300">
-                          <span className="w-3 h-3 rounded-full border-2 border-teal-400/40 border-t-teal-300 animate-spin" />
-                          Verificando resolución del servicio...
-                        </div>
-                        <p className="text-xs text-teal-400/60">
-                          El agente está comprobando si el contenedor volvió a estado running.
-                        </p>
-                      </div>
-                    )}
-
-                    {selected.status === 'resolved' && selected.executed_at && (
-                      <div className="inline-flex items-center gap-2 text-xs text-emerald-400">
-                        <span className="w-2 h-2 rounded-full bg-emerald-400" />
-                        Servicio verificado y recuperado
-                      </div>
-                    )}
-
-                    {actionError && selected.status !== 'failed' && (
-                      <p className="text-xs text-red-300 bg-red-500/10 border border-red-500/25 rounded-md px-3 py-2">
-                        {actionError}
-                      </p>
-                    )}
-
-                    {(selected.action_result || actionResponse?.stdout) && (
-                      <div>
-                        <p className="text-xs text-slate-500 mb-1">Resultado (stdout)</p>
-                        <pre className="bg-slate-950 border border-slate-800 rounded-md p-3 text-xs text-emerald-300 font-mono overflow-x-auto whitespace-pre-wrap">
-                          {selected.action_result || actionResponse?.stdout}
-                        </pre>
-                      </div>
-                    )}
-
-                    {(selected.status === 'failed' || actionResponse?.status === 'failed') && (
-                      <div className="space-y-2">
-                        <div>
-                          <p className="text-xs text-slate-500 mb-1">Error técnico (stderr)</p>
-                          <pre className="bg-slate-950 border border-red-900/60 rounded-md p-3 text-xs text-red-300 font-mono overflow-x-auto whitespace-pre-wrap">
-                            {selected.action_error || actionResponse?.stderr || actionError || 'Sin detalle técnico'}
-                          </pre>
-                        </div>
-                        <p className="text-sm text-amber-300">
-                          La ejecución automática falló. Se recomienda revisión manual.
-                        </p>
-                        <p className="text-xs text-slate-400">
-                          Se recomienda revisión manual: revisar logs y ejecutar el comando manualmente si aplica.
-                        </p>
-                        <div className="flex items-center gap-2">
-                          {selected.proposed_action && (
-                            <button
-                              onClick={handleApproveAction}
-                              disabled={actionLoading}
-                              className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors disabled:opacity-50"
-                            >
-                              {actionLoading ? 'Reintentando...' : 'Reintentar'}
-                            </button>
-                          )}
-                          <button
-                            onClick={() =>
-                              document
-                                .getElementById('incident-logs-section')
-                                ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                            }
-                            className="border border-slate-700 hover:border-slate-500 text-slate-300 rounded-md px-3 py-1.5 text-xs transition-colors"
-                          >
-                            Ver logs
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         ) : (

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -70,8 +70,9 @@ function IncidentTypeBadge({ type }) {
 }
 
 const RUNTIME_CONFIG = {
-  docker:   { label: 'docker',   className: 'bg-blue-900/40 text-blue-400' },
-  kubernetes: { label: 'k8s', className: 'bg-cyan-900/40 text-cyan-400' },
+  docker:     { label: 'docker',  className: 'bg-blue-900/40 text-blue-400' },
+  podman:     { label: 'podman',  className: 'bg-purple-900/40 text-purple-400' },
+  kubernetes: { label: 'k8s',    className: 'bg-cyan-900/40 text-cyan-400' },
   database: { label: 'database', className: 'bg-amber-900/40 text-amber-400' },
 }
 

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import AgentReasoningPanel from '../components/AgentReasoningPanel'
 import RunbookViewer from '../components/RunbookViewer'
 import SimilarIncidentsCard from '../components/SimilarIncidentsCard'
 import ApprovalModal from '../components/ApprovalModal'
+import IncidentTimeline from '../components/IncidentTimeline'
 import { executeIncidentAction } from '../services/incidentActions'
 
 const SEVERITY_CONFIG = {
@@ -402,6 +403,13 @@ export default function Dashboard() {
               <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-start">
                 {/* Columna izquierda: evidencia + análisis del agente */}
                 <div className="space-y-5 min-w-0">
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                      Línea de tiempo
+                    </p>
+                    <IncidentTimeline incident={selected} />
+                  </div>
+
                   <div id="incident-logs-section">
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
                       Logs del contenedor
@@ -422,7 +430,7 @@ export default function Dashboard() {
                     selected.status === 'detected') && (
                     <div>
                       <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
-                        Línea de tiempo y análisis
+                        Análisis del agente
                       </p>
                       <AgentReasoningPanel
                         reasoning={selected.agent_reasoning}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -5,6 +5,8 @@ import { supabase } from '../lib/supabase'
 import { useIncidentNotifications } from '../hooks/useIncidentNotifications'
 import CreateIncidentModal from '../components/CreateIncidentModal'
 import AgentReasoningPanel from '../components/AgentReasoningPanel'
+import RunbookViewer from '../components/RunbookViewer'
+import SimilarIncidentsCard from '../components/SimilarIncidentsCard'
 import { executeIncidentAction } from '../services/incidentActions'
 
 const SEVERITY_CONFIG = {
@@ -423,6 +425,20 @@ export default function Dashboard() {
                       />
                     </div>
                   )}
+
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                      Runbooks relevantes
+                    </p>
+                    <RunbookViewer incidentId={selected.id} />
+                  </div>
+
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                      Incidentes similares
+                    </p>
+                    <SimilarIncidentsCard incidentId={selected.id} />
+                  </div>
                 </div>
 
                 {/* Columna derecha: acciones / ejecución (sticky) */}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -23,7 +23,8 @@ const STATUS_CONFIG = {
   analyzed: { label: 'Analizado', className: 'bg-amber-500/15 text-amber-400' },
   awaiting_approval: { label: 'Esperando aprobación', className: 'bg-cyan-500/15 text-cyan-400' },
   executing_solution: { label: 'Ejecutando solución', className: 'bg-indigo-500/15 text-indigo-300' },
-  resolved: { label: 'Resuelto', className: 'bg-slate-500/15 text-slate-500' },
+  verifying: { label: 'Verificando', className: 'bg-teal-500/15 text-teal-300' },
+  resolved: { label: 'Resuelto', className: 'bg-emerald-500/15 text-emerald-400' },
   failed: { label: 'Falló', className: 'bg-red-500/15 text-red-400' },
 }
 
@@ -477,6 +478,25 @@ export default function Dashboard() {
                       <div className="inline-flex items-center gap-2 text-xs text-indigo-300">
                         <span className="w-3 h-3 rounded-full border-2 border-indigo-400/40 border-t-indigo-300 animate-spin" />
                         Ejecutando comando...
+                      </div>
+                    )}
+
+                    {selected.status === 'verifying' && (
+                      <div className="bg-teal-500/10 border border-teal-500/25 rounded-md px-3 py-2.5 space-y-1">
+                        <div className="inline-flex items-center gap-2 text-xs text-teal-300">
+                          <span className="w-3 h-3 rounded-full border-2 border-teal-400/40 border-t-teal-300 animate-spin" />
+                          Verificando resolución del servicio...
+                        </div>
+                        <p className="text-xs text-teal-400/60">
+                          El agente está comprobando si el contenedor volvió a estado running.
+                        </p>
+                      </div>
+                    )}
+
+                    {selected.status === 'resolved' && selected.executed_at && (
+                      <div className="inline-flex items-center gap-2 text-xs text-emerald-400">
+                        <span className="w-2 h-2 rounded-full bg-emerald-400" />
+                        Servicio verificado y recuperado
                       </div>
                     )}
 

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -160,7 +160,11 @@ export default function Dashboard() {
           })
           pushIncidentNotification(payload.new)
         } else if (payload.eventType === 'UPDATE') {
-          setIncidents((prev) => prev.map((i) => (i.id === payload.new.id ? payload.new : i)))
+          setIncidents((prev) =>
+            prev.map((i) =>
+              i.id === payload.new.id ? { ...i, ...payload.new } : i,
+            ),
+          )
           pushIncidentNotification(payload.new)
         } else if (payload.eventType === 'DELETE') {
           setIncidents((prev) => prev.filter((i) => i.id !== payload.old.id))

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import CreateIncidentModal from '../components/CreateIncidentModal'
 import AgentReasoningPanel from '../components/AgentReasoningPanel'
 import RunbookViewer from '../components/RunbookViewer'
 import SimilarIncidentsCard from '../components/SimilarIncidentsCard'
+import ApprovalModal from '../components/ApprovalModal'
 import { executeIncidentAction } from '../services/incidentActions'
 
 const SEVERITY_CONFIG = {
@@ -112,6 +113,7 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const [showApprovalModal, setShowApprovalModal] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
   const [actionError, setActionError] = useState(null)
   const [actionResponse, setActionResponse] = useState(null)
@@ -190,6 +192,7 @@ export default function Dashboard() {
     setActionLoading(false)
     setActionError(null)
     setActionResponse(null)
+    setShowApprovalModal(false)
   }, [selectedIncidentId])
 
   const openIncident = (incident) => {
@@ -462,11 +465,10 @@ export default function Dashboard() {
 
                     {selected.status === 'awaiting_approval' && selected.proposed_action && (
                       <button
-                        onClick={handleApproveAction}
-                        disabled={actionLoading}
-                        className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
+                        onClick={() => setShowApprovalModal(true)}
+                        className="w-full bg-emerald-600 hover:bg-emerald-500 text-white rounded-md px-4 py-2 text-sm font-medium transition-colors"
                       >
-                        {actionLoading ? 'Aprobando...' : 'Aprobar'}
+                        Revisar y aprobar acción
                       </button>
                     )}
 
@@ -544,6 +546,29 @@ export default function Dashboard() {
       </div>
 
       {showCreateModal && <CreateIncidentModal onClose={() => setShowCreateModal(false)} />}
+
+      {showApprovalModal && selected && (
+        <ApprovalModal
+          incident={selected}
+          onApprove={async (comment) => {
+            setActionLoading(true)
+            setActionError(null)
+            try {
+              const response = await executeIncidentAction({
+                incidentId: selected.id,
+                command: selected.proposed_action,
+              })
+              setActionResponse(response)
+            } catch (err) {
+              setActionError(err.message)
+              throw err
+            } finally {
+              setActionLoading(false)
+            }
+          }}
+          onClose={() => setShowApprovalModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/Frontend/src/services/incidentActions.js
+++ b/Frontend/src/services/incidentActions.js
@@ -1,0 +1,31 @@
+import { supabase } from '../lib/supabase'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+export async function executeIncidentAction({ incidentId, command }) {
+  const { data: { session } } = await supabase.auth.getSession()
+
+  if (!session?.access_token) {
+    throw new Error('No se encontro sesion activa. Inicia sesion de nuevo.')
+  }
+
+  const res = await fetch(`${API_URL}/api/execute-action`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({
+      incident_id: incidentId,
+      command,
+    }),
+  })
+
+  const data = await res.json().catch(() => null)
+
+  if (!res.ok) {
+    throw new Error(data?.detail || `Error ${res.status}: no se pudo ejecutar la accion`)
+  }
+
+  return data
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,21 @@ services:
       - postgres-demo
     restart: unless-stopped
 
+  # ── Exporter de métricas Podman → Prometheus ──────────────────────────────
+  # Requiere Podman instalado en el host con el socket rootless activo.
+  # En Linux: systemctl --user enable --now podman.socket
+  # El socket estándar es /run/user/1000/podman/podman.sock (UID 1000).
+  podman-exporter:
+    image: quay.io/navidys/prometheus-podman-exporter:latest
+    container_name: sentinel-podman-exporter
+    environment:
+      PODMAN_URL: "unix:///run/podman/podman.sock"
+    volumes:
+      - /run/user/1000/podman/podman.sock:/run/podman/podman.sock:ro
+    ports:
+      - "9882:9882"
+    restart: unless-stopped
+
   # ── Vector DB para RAG (runbooks y conocimiento del agente) ────────────────
   chromadb:
     image: chromadb/chroma:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - "8000:8000"
     volumes:
       - ./Backend:/app
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Needed for /api/execute-action to restart/log containers via Docker CLI.
+      - /var/run/docker.sock:/var/run/docker.sock:rw
       - backend_env:/app/env        # aísla virtualenv del host → evita WatchFiles storms
       - chroma_cache:/root/.cache/chroma  # persiste modelo ONNX (~79MB) entre reinicios
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "8000:8000"
     volumes:
       - ./Backend:/app
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /run/docker.sock:/var/run/docker.sock:ro
       - backend_env:/app/env        # aísla virtualenv del host → evita WatchFiles storms
       - chroma_cache:/root/.cache/chroma  # persiste modelo ONNX (~79MB) entre reinicios
     extra_hosts:
@@ -45,17 +45,18 @@ services:
     restart: unless-stopped
 
   # ── Métricas de contenedores Docker ────────────────────────────────────────
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
-    container_name: sentinel-cadvisor
-    privileged: true
-    volumes:
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    ports:
-      - "8080:8080"
-    restart: unless-stopped
+  # cAdvisor deshabilitado: incompatible con Podman en macOS (monta /var/run y /sys del host)
+  # cadvisor:
+  #   image: gcr.io/cadvisor/cadvisor:latest
+  #   container_name: sentinel-cadvisor
+  #   privileged: true
+  #   volumes:
+  #     - /var/run:/var/run:ro
+  #     - /sys:/sys:ro
+  #     - /run/docker.sock:/var/run/docker.sock:ro
+  #   ports:
+  #     - "8082:8080"
+  #   restart: unless-stopped
 
   # ── Recolección de métricas y evaluación de reglas ─────────────────────────
   prometheus:
@@ -71,8 +72,6 @@ services:
       - "--web.enable-lifecycle"
     ports:
       - "9090:9090"
-    depends_on:
-      - cadvisor
     restart: unless-stopped
 
   # ── Enrutamiento de alertas al backend de Sentinel ─────────────────────────
@@ -104,7 +103,7 @@ services:
     image: grafana/promtail:latest
     container_name: sentinel-promtail
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/docker.sock:/var/run/docker.sock
       - ./promtail/promtail-config.yml:/etc/promtail/config.yml
     command: -config.file=/etc/promtail/config.yml
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,20 @@ services:
       CHROMA_HOST: "http://chromadb:8000"
       LOKI_URL: "http://loki:3100"
       LANGFUSE_HOST: "http://langfuse:3000"
+      PROMETHEUS_URL: "http://prometheus:9090"
       PYTHONDONTWRITEBYTECODE: "1"   # evita __pycache__ en código fuente → no dispara WatchFiles
+      # Socket de Podman: en Linux rootless el UID suele ser 1000.
+      # Si el host usa un UID diferente, ajustar la ruta del volumen y esta variable.
+      # En macOS (Docker Desktop) este socket no existe y la variable queda sin efecto.
+      PODMAN_HOST: "unix:///run/podman/podman.sock"
     ports:
       - "8000:8000"
     volumes:
       - ./Backend:/app
       - /var/run/docker.sock:/var/run/docker.sock:rw
+      # Socket de Podman (solo disponible en Linux con Podman instalado).
+      # En macOS Docker Desktop este path no existe; Docker Compose lo ignora silenciosamente.
+      - /run/user/1000/podman/podman.sock:/run/podman/podman.sock:rw
       - backend_env:/app/env        # aísla virtualenv del host → evita WatchFiles storms
       - chroma_cache:/root/.cache/chroma  # persiste modelo ONNX (~79MB) entre reinicios
     extra_hosts:
@@ -45,18 +53,22 @@ services:
     restart: unless-stopped
 
   # ── Métricas de contenedores Docker ────────────────────────────────────────
-  # cAdvisor deshabilitado: incompatible con Podman en macOS (monta /var/run y /sys del host)
-  # cadvisor:
-  #   image: gcr.io/cadvisor/cadvisor:latest
-  #   container_name: sentinel-cadvisor
-  #   privileged: true
-  #   volumes:
-  #     - /var/run:/var/run:ro
-  #     - /sys:/sys:ro
-  #     - /run/docker.sock:/var/run/docker.sock:ro
-  #   ports:
-  #     - "8082:8080"
-  #   restart: unless-stopped
+  # cAdvisor: funciona en macOS (Docker Desktop usa VM Linux, /sys y /var/run
+  # son paths del VM) y en Linux. Podman usa un exporter separado (podman-exporter).
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: sentinel-cadvisor
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+    command:
+      - --docker_only=true
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
 
   # ── Recolección de métricas y evaluación de reglas ─────────────────────────
   prometheus:

--- a/podman.sh
+++ b/podman.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run podman-compose with the correct Podman socket wired in.
+# Usage:  ./podman.sh up -d
+#         ./podman.sh down
+#         ./podman.sh logs -f backend
+set -euo pipefail
+
+# Ensure Podman machine is running
+if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q running; then
+    echo "Starting Podman machine..."
+    podman machine start
+fi
+
+# Point DOCKER_HOST at the macOS-side socket so host tooling (e.g. podman-compose) can reach the daemon
+SOCKET_PATH="$(podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2>/dev/null)"
+export DOCKER_HOST="unix://${SOCKET_PATH}"
+
+# Load Podman-specific env vars (DOCKER_SOCKET, etc.) into the environment
+set -a
+# shellcheck source=.env.podman
+source "$(dirname "$0")/.env.podman"
+set +a
+
+exec podman-compose "$@"

--- a/prometheus/alert_rules.yml
+++ b/prometheus/alert_rules.yml
@@ -180,6 +180,108 @@ groups:
             lleva 5 minutos usando el {{ printf "%.0f" $value }}% de su límite de swap.
             Posible presión de memoria sostenida.
 
+# ── Podman Alerts (prometheus-podman-exporter) ───────────────────────────────
+# Requiere prometheus-podman-exporter corriendo con acceso al socket de Podman.
+# Todas las alertas incluyen container_runtime: podman para que alert_processor
+# enrute los incidentes al PodmanAgent.
+  - name: podman_container_alerts
+    interval: 10s
+    rules:
+
+      # Contenedor caído — estado exited (4) o stopped (2) de forma inesperada
+      - alert: PodmanContainerCrashed
+        expr: >
+          podman_container_state{name!=""} == 4
+        for: 0m
+        labels:
+          severity: high
+          container_runtime: podman
+        annotations:
+          summary: >-
+            Contenedor Podman caído: {{ $labels.name }}
+          description: >-
+            El contenedor Podman {{ $labels.name }} está en estado exited.
+            Posible crash o fallo inesperado del proceso.
+
+      # OOM Kill — el kernel terminó el contenedor por falta de memoria
+      - alert: PodmanContainerOOMKilled
+        expr: >
+          increase(podman_container_oom_events_total{name!=""}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          container_runtime: podman
+        annotations:
+          summary: >-
+            OOM Kill en contenedor Podman: {{ $labels.name }}
+          description: >-
+            El contenedor Podman {{ $labels.name }} fue terminado por el OOM Killer del kernel.
+            Se registraron {{ printf "%.0f" $value }} evento(s) de OOM en los últimos 5 minutos.
+
+      # Alta memoria — uso supera el 85% del límite configurado
+      - alert: PodmanContainerHighMemory
+        expr: >
+          (
+            podman_container_mem_usage_bytes{name!=""}
+            / podman_container_mem_limit_bytes{name!=""}
+          ) * 100 > 85
+          and podman_container_mem_limit_bytes{name!=""} > 0
+        for: 2m
+        labels:
+          severity: high
+          container_runtime: podman
+        annotations:
+          summary: >-
+            Memoria al {{ printf "%.0f" $value }}% del límite: {{ $labels.name }}
+          description: >-
+            El contenedor Podman {{ $labels.name }} lleva más de 2 minutos usando
+            el {{ printf "%.0f" $value }}% de su límite de memoria. OOM Kill inminente.
+
+      # CPU elevada — uso de CPU supera el 80% sostenido
+      - alert: PodmanContainerCPUThrottling
+        expr: >
+          rate(podman_container_cpu_seconds_total{name!=""}[5m]) * 100 > 80
+        for: 5m
+        labels:
+          severity: medium
+          container_runtime: podman
+        annotations:
+          summary: >-
+            CPU al {{ printf "%.0f" $value }}%: {{ $labels.name }}
+          description: >-
+            El contenedor Podman {{ $labels.name }} lleva 5 minutos con uso de CPU
+            al {{ printf "%.0f" $value }}%. La aplicación puede estar degradada.
+
+      # Restart loop — el contenedor cambió de estado 3 o más veces en 10 minutos
+      - alert: PodmanContainerRestartLoop
+        expr: >
+          changes(podman_container_state{name!=""}[10m]) >= 3
+        for: 0m
+        labels:
+          severity: high
+          container_runtime: podman
+        annotations:
+          summary: >-
+            Restart loop ({{ printf "%.0f" $value }} cambios de estado): {{ $labels.name }}
+          description: >-
+            El contenedor Podman {{ $labels.name }} cambió de estado {{ printf "%.0f" $value }}
+            veces en los últimos 10 minutos. Posible CrashLoop.
+
+      # Contenedor detenido — estado stopped/paused por tiempo inesperado
+      - alert: PodmanContainerUnhealthy
+        expr: >
+          podman_container_state{name!=""} == 2
+        for: 3m
+        labels:
+          severity: high
+          container_runtime: podman
+        annotations:
+          summary: >-
+            Contenedor Podman detenido: {{ $labels.name }}
+          description: >-
+            El contenedor Podman {{ $labels.name }} lleva más de 3 minutos en estado
+            stopped. Puede indicar un problema de health o fallo al reiniciar.
+
 # ── PostgreSQL Alerts (postgres-exporter) ────────────────────────────────────
 # Requiere postgres-exporter corriendo y configurado en prometheus.yml.
 # Todas las alertas incluyen source_type: database para que alert_processor

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -31,3 +31,9 @@ scrape_configs:
     static_configs:
       - targets: ["postgres-exporter:9187"]
     metrics_path: /metrics
+
+  # Métricas de contenedores Podman vía prometheus-podman-exporter
+  - job_name: "podman"
+    static_configs:
+      - targets: ["podman-exporter:9882"]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary

- **US-06b** — Panel de métricas en vivo via Prometheus (`MetricsPanel.jsx` + `GET /api/incidents/{id}/metrics`) para Docker y PostgreSQL
- **US-07** — Timeline de evolución del incidente (`IncidentTimeline.jsx`) con los 8 estados del ciclo de vida
- **US-08b** — Propuesta de solución automática para Docker, Podman y PostgreSQL (`supervisor.py`)
- **US-09** — Búsqueda en base de conocimiento (`RunbookViewer.jsx` + ChromaDB por dominio)
- **US-10** — Incidentes similares (`SimilarIncidentsCard.jsx` + memoria episódica ChromaDB)
- **HU-11** — Ejecución guiada: `POST /api/execute-action` con whitelist estricta (docker/podman restart/logs, pg_stat_activity/cancel/terminate)
- **HU-12** — Modal de aprobación de alto riesgo (`ApprovalModal.jsx` + endpoints `/reject` y `/postpone`)
- **HU-13** — Verificación post-acción (`verification.py`): espera 8s, inspecciona contenedor/BD, actualiza a `resolved` o `failed`
- **Podman** — `PodmanAgent` + 6 reglas de alerta Prometheus + runbooks + podman-exporter en docker-compose
- **PostgreSQL** — `PostgresAgent` + `_run_pg_command` (psycopg2) + verificación de salud post-acción
- **Dashboard** — Refactor con 4 tabs: Resumen, Evidencia, Análisis, Conocimiento
- **Fix** — `Optional[str]` en Python 3.9 (`str | None` solo funciona en 3.10+)
- **Fix** — cAdvisor re-habilitado con socket Docker `:rw` para exponer label `name` en métricas
- **Fix** — `prometheus.py` resuelve nombre → ID completo via Docker SDK (workaround cAdvisor en macOS)

## Ciclo de vida completo (Sprint 2)
```
detected → investigating → analyzed → awaiting_approval → executing_solution → verifying → resolved
                                                                                           ↘ failed
```

## Test plan
- [ ] Crear incidente Docker manual → verificar que el agente propone `docker restart <name>`
- [ ] Aprobar acción → verificar transición `executing_solution → verifying → resolved`
- [ ] Crear incidente PostgreSQL → verificar propuesta `pg_terminate_backend sentinel_demo`
- [ ] Rechazar acción → verificar status `failed` con nota
- [ ] Tab Evidencia → verificar métricas Docker + logs
- [ ] Tab Conocimiento → verificar runbooks y similares
- [ ] Podman (Linux): crear incidente → verificar propuesta `podman restart <name>`

## Notas
- Podman solo probado en Linux (socket `/run/user/1000/podman/podman.sock`)
- cAdvisor puede tardar ~60s en exponer métricas de contenedores nuevos

