### PR TITLE
Production hardening: webhook auth, audit trail, atomic approvals y recovery de huérfanos

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -1,24 +1,50 @@
+import os
+from contextlib import asynccontextmanager
+
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from routers import actions, alerts, health, incidents
+from services.recovery import start_recovery_loop
+
+load_dotenv()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    # Rescata incidentes huérfanos (atascados por reinicios) al arrancar y cada 15 min.
+    start_recovery_loop()
+    yield
+
 
 app = FastAPI(
     title="Sentinel-SoftServe API",
     description="Backend API para el proyecto Sentinel-SoftServe",
     version="1.0.0",
+    lifespan=lifespan,
+)
+
+# CORS configurable por entorno:
+#   CORS_ORIGINS       — lista separada por comas (ej. "https://sentinel-softserve-1.onrender.com")
+#   CORS_ORIGIN_REGEX  — regex opcional para orígenes dinámicos
+# Defaults: Vite dev server en localhost, 127.0.0.1 o una IP LAN. Si CORS no
+# incluye el origen exacto, el navegador lo reporta como "TypeError: Failed to fetch".
+_default_origins = "http://localhost:5173,http://127.0.0.1:5173"
+_cors_origins = [
+    o.strip()
+    for o in os.getenv("CORS_ORIGINS", _default_origins).split(",")
+    if o.strip()
+]
+_cors_origin_regex = os.getenv(
+    "CORS_ORIGIN_REGEX",
+    r"^http://(\d{1,3}\.){3}\d{1,3}:5173$",
 )
 
 app.add_middleware(
     CORSMiddleware,
-    # Dev note: the Vite dev server can be accessed as localhost, 127.0.0.1,
-    # or a LAN IP (e.g. http://192.168.x.x:5173). If CORS doesn't include the
-    # exact origin, browsers surface it as "TypeError: Failed to fetch".
-    allow_origins=[
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-    ],
-    allow_origin_regex=r"^http://(\d{1,3}\.){3}\d{1,3}:5173$",
+    allow_origins=_cors_origins,
+    allow_origin_regex=_cors_origin_regex or None,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/Backend/routers/actions.py
+++ b/Backend/routers/actions.py
@@ -27,6 +27,11 @@ _PG_ALLOWED_FUNCS    = {"pg_stat_activity", "pg_cancel_backend", "pg_terminate_b
 _PODMAN_ALLOWED_CMDS = {"restart", "logs"}
 
 
+def _user_identity(user: dict) -> str:
+    """Identidad legible del usuario autenticado para auditoría (email o sub del JWT)."""
+    return user.get("email") or user.get("sub") or "unknown"
+
+
 class ExecuteActionRequest(BaseModel):
     incident_id: str = Field(..., min_length=1)
     command: str = Field(..., min_length=1, max_length=200)
@@ -362,7 +367,22 @@ async def execute_action(
         or requested_command.startswith("kubectl ")
     )
 
-    supabase.table("incidents").update({"status": "executing_solution"}).eq("id", body.incident_id).execute()
+    # Claim atómico: solo gana quien encuentre el incidente todavía en
+    # 'awaiting_approval'. Si otro usuario lo ejecutó en paralelo, el UPDATE
+    # no afecta filas y respondemos 409 en lugar de ejecutar dos veces.
+    approved_by = _user_identity(user)
+    claim = (
+        supabase.table("incidents")
+        .update({"status": "executing_solution", "approved_by": approved_by})
+        .eq("id", body.incident_id)
+        .eq("status", "awaiting_approval")
+        .execute()
+    )
+    if not claim.data:
+        raise HTTPException(
+            status_code=409,
+            detail="La accion ya fue ejecutada o el incidente cambio de estado",
+        )
     record_event(body.incident_id, "executing_solution")
     executed_at = datetime.now(tz=timezone.utc).isoformat()
 
@@ -572,23 +592,34 @@ class ActionDecisionRequest(BaseModel):
     comment: str = Field(default="", max_length=500)
 
 
-def _get_awaiting_incident(incident_id: str):
-    response = (
+def _decide_awaiting_incident(incident_id: str, update_fields: dict) -> None:
+    """
+    Aplica la decisión (rechazar/posponer) de forma atómica: el UPDATE solo
+    procede si el incidente sigue en 'awaiting_approval'. Distingue 404 de 409
+    consultando el incidente cuando el claim no afecta filas.
+    """
+    claim = (
         supabase.table("incidents")
-        .select("id,status")
+        .update(update_fields)
         .eq("id", incident_id)
-        .single()
+        .eq("status", "awaiting_approval")
         .execute()
     )
-    incident = response.data
-    if not incident:
+    if claim.data:
+        return
+
+    exists = (
+        supabase.table("incidents")
+        .select("id")
+        .eq("id", incident_id)
+        .execute()
+    )
+    if not exists.data:
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
-    if incident.get("status") != "awaiting_approval":
-        raise HTTPException(
-            status_code=409,
-            detail="El incidente no está en estado 'Esperando aprobación'",
-        )
-    return incident
+    raise HTTPException(
+        status_code=409,
+        detail="El incidente no está en estado 'Esperando aprobación'",
+    )
 
 
 @router.post("/incidents/{incident_id}/reject")
@@ -597,13 +628,13 @@ async def reject_action(
     body: ActionDecisionRequest,
     user=Depends(get_current_user),
 ):
-    _get_awaiting_incident(incident_id)
     note = body.comment.strip() or "Acción rechazada por el ingeniero."
-    supabase.table("incidents").update({
+    _decide_awaiting_incident(incident_id, {
         "status": "failed",
         "action_error": f"[RECHAZADO] {note}",
+        "approved_by": _user_identity(user),
         "executed_at": datetime.now(tz=timezone.utc).isoformat(),
-    }).eq("id", incident_id).execute()
+    })
     record_event(incident_id, "failed")
     return {"incident_id": incident_id, "status": "failed", "note": note}
 
@@ -614,11 +645,11 @@ async def postpone_action(
     body: ActionDecisionRequest,
     user=Depends(get_current_user),
 ):
-    _get_awaiting_incident(incident_id)
     note = body.comment.strip() or "Acción pospuesta por el ingeniero."
-    supabase.table("incidents").update({
+    _decide_awaiting_incident(incident_id, {
         "status": "analyzed",
         "action_error": f"[POSPUESTO] {note}",
-    }).eq("id", incident_id).execute()
+        "approved_by": _user_identity(user),
+    })
     record_event(incident_id, "analyzed")
     return {"incident_id": incident_id, "status": "analyzed", "note": note}

--- a/Backend/routers/alerts.py
+++ b/Backend/routers/alerts.py
@@ -1,12 +1,48 @@
+import hmac
+import logging
+import os
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException
 from pydantic import BaseModel
 
 from services.alert_processor import process_prometheus_alert
 from services.langgraph_engine import run_langgraph_engine
 
 router = APIRouter(prefix="/api", tags=["alerts"])
+
+logger = logging.getLogger(__name__)
+
+_webhook_secret_warned = False
+
+
+def _verify_webhook_secret(authorization: Optional[str]) -> None:
+    """
+    Valida el secreto compartido del webhook (ALERT_WEBHOOK_SECRET).
+
+    Alertmanager lo envía como 'Authorization: Bearer <secreto>' (ver
+    http_config.authorization en alertmanager.yml). Si la variable de entorno
+    no está configurada, el endpoint queda abierto (modo desarrollo) y se
+    loguea una advertencia una sola vez.
+    """
+    global _webhook_secret_warned
+    secret = os.getenv("ALERT_WEBHOOK_SECRET", "").strip()
+
+    if not secret:
+        if not _webhook_secret_warned:
+            logger.warning(
+                "[alerts] ALERT_WEBHOOK_SECRET no configurado — el webhook "
+                "/api/alerts acepta peticiones sin autenticar. No usar así en producción."
+            )
+            _webhook_secret_warned = True
+        return
+
+    provided = ""
+    if authorization and authorization.lower().startswith("bearer "):
+        provided = authorization[len("Bearer "):]
+
+    if not hmac.compare_digest(provided, secret):
+        raise HTTPException(status_code=401, detail="Webhook no autorizado")
 
 
 class AlertmanagerAlert(BaseModel):
@@ -35,11 +71,15 @@ class AlertmanagerWebhook(BaseModel):
 async def receive_alertmanager_webhook(
     webhook: AlertmanagerWebhook,
     background_tasks: BackgroundTasks,
+    authorization: Optional[str] = Header(default=None),
 ):
     """
     Recibe webhooks de Prometheus Alertmanager y crea incidentes en Sentinel.
     Si la alerta es 'firing', lanza el motor LangGraph en background.
+    Requiere 'Authorization: Bearer <ALERT_WEBHOOK_SECRET>' cuando el secreto
+    está configurado.
     """
+    _verify_webhook_secret(authorization)
     for alert in webhook.alerts:
         result = process_prometheus_alert(alert.model_dump())
         if result:

--- a/Backend/routers/incidents.py
+++ b/Backend/routers/incidents.py
@@ -226,12 +226,26 @@ async def create_incident(
     return created_incident
 
 
-def _runbook_collection(source_type: str) -> str:
-    return "runbooks-postgres" if source_type == "database" else "runbooks-docker"
+def _memory_domain(source_type: str, container_runtime: Optional[str]) -> str:
+    """
+    Dominio de memoria ChromaDB del incidente. Debe coincidir con la convención
+    de DomainAgent (`runbooks-{name}` / `incidents-{name}`): docker, podman,
+    kubernetes o postgres.
+    """
+    if source_type == "database":
+        return "postgres"
+    runtime = (container_runtime or "").lower()
+    if runtime in ("podman", "kubernetes"):
+        return runtime
+    return "docker"
 
 
-def _incidents_collection(source_type: str) -> str:
-    return "incidents-postgres" if source_type == "database" else "incidents-docker"
+def _runbook_collection(source_type: str, container_runtime: Optional[str] = None) -> str:
+    return f"runbooks-{_memory_domain(source_type, container_runtime)}"
+
+
+def _incidents_collection(source_type: str, container_runtime: Optional[str] = None) -> str:
+    return f"incidents-{_memory_domain(source_type, container_runtime)}"
 
 
 def _parse_runbook_title(text: str) -> str:
@@ -251,7 +265,7 @@ async def get_incident_runbooks(
     try:
         response = (
             supabase.table("incidents")
-            .select("source_type,incident_type,title")
+            .select("source_type,container_runtime,incident_type,title")
             .eq("id", incident_id)
             .single()
             .execute()
@@ -262,7 +276,10 @@ async def get_incident_runbooks(
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
 
     incident = response.data
-    collection = _runbook_collection(incident.get("source_type") or "container")
+    collection = _runbook_collection(
+        incident.get("source_type") or "container",
+        incident.get("container_runtime"),
+    )
     query = q or f"{incident.get('incident_type') or 'unknown'} {incident.get('title') or ''}"
 
     texts = query_runbooks(collection, query.strip(), k=5)
@@ -277,7 +294,7 @@ async def get_similar_incidents(
     try:
         response = (
             supabase.table("incidents")
-            .select("source_type,incident_type,title,severity")
+            .select("source_type,container_runtime,incident_type,title,severity")
             .eq("id", incident_id)
             .single()
             .execute()
@@ -288,7 +305,10 @@ async def get_similar_incidents(
         raise HTTPException(status_code=404, detail="Incidente no encontrado")
 
     incident = response.data
-    collection = _incidents_collection(incident.get("source_type") or "container")
+    collection = _incidents_collection(
+        incident.get("source_type") or "container",
+        incident.get("container_runtime"),
+    )
     query = f"{incident.get('incident_type') or 'unknown'} {incident.get('title') or ''}"
 
     results = query_incidents(collection, query.strip(), k=6)

--- a/Backend/services/alert_processor.py
+++ b/Backend/services/alert_processor.py
@@ -273,6 +273,7 @@ def process_prometheus_alert(alert: dict) -> Optional[Tuple[str, str, str, str, 
         return None
 
     title = _build_title(alert_name, target, source_type)
+    fingerprint = (alert.get("fingerprint") or "").strip() or None
 
     incident = {
         "title":             title,
@@ -283,6 +284,7 @@ def process_prometheus_alert(alert: dict) -> Optional[Tuple[str, str, str, str, 
         "container_runtime": container_runtime,
         "logs":              logs or None,
         "server_name":       server_name,
+        "fingerprint":       fingerprint,
     }
 
     try:
@@ -293,6 +295,16 @@ def process_prometheus_alert(alert: dict) -> Optional[Tuple[str, str, str, str, 
             f"source: {source_type}, runtime: {container_runtime}, severidad: {severity}"
         )
     except Exception as e:
+        # El índice único parcial sobre fingerprint (migración 0002) garantiza
+        # a nivel de BD que no haya dos incidentes activos para la misma alerta,
+        # incluso si varias llegan en paralelo y pasan el check anterior.
+        message = str(e)
+        if "23505" in message or "duplicate key" in message.lower():
+            logger.info(
+                f"Incidente activo ya existe para fingerprint '{fingerprint}' "
+                f"({alert_name}) — omitiendo duplicado"
+            )
+            return None
         logger.error(f"Error al crear incidente en Supabase: {e}")
         return None
 

--- a/Backend/services/recovery.py
+++ b/Backend/services/recovery.py
@@ -1,0 +1,121 @@
+"""
+Rescate de incidentes huérfanos.
+
+El triage corre como BackgroundTask de FastAPI: si el proceso se reinicia
+(deploy, crash, dyno dormido) a mitad de pipeline, el incidente queda
+atascado para siempre en un estado de procesamiento ('detected',
+'investigating', 'executing_solution', 'verifying') sin que nadie lo retome.
+
+Este módulo corre un sweep al arrancar y luego cada SWEEP_INTERVAL_SEC:
+los incidentes en estado de procesamiento cuya última actividad supera
+STUCK_THRESHOLD_MIN se marcan como 'failed' con una nota explicativa, para
+que el ingeniero los vea en el dashboard en lugar de creer que siguen en curso.
+
+'analyzed' y 'awaiting_approval' NO se tocan: son estados de espera humana
+legítimamente largos.
+"""
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+from db.supabase_client import supabase
+from services.incident_events import record_event
+
+logger = logging.getLogger(__name__)
+
+STUCK_THRESHOLD_MIN = int(os.getenv("RECOVERY_STUCK_THRESHOLD_MIN", "30"))
+SWEEP_INTERVAL_SEC = int(os.getenv("RECOVERY_SWEEP_INTERVAL_SEC", "900"))
+
+# Estados transitorios que un proceso vivo resuelve en segundos/minutos.
+_PROCESSING_STATUSES = ("detected", "investigating", "executing_solution", "verifying")
+
+_ORPHAN_NOTE = (
+    "[RECOVERY] El incidente quedó huérfano: el backend se reinició mientras "
+    "el pipeline estaba en curso y el procesamiento no se retomó. "
+    "Requiere revisión manual."
+)
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def sweep_orphaned_incidents() -> int:
+    """
+    Marca como 'failed' los incidentes atascados en estados de procesamiento.
+    Retorna cuántos se rescataron.
+    """
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=STUCK_THRESHOLD_MIN)
+    rescued = 0
+
+    try:
+        response = (
+            supabase.table("incidents")
+            .select("id,status,created_at,executed_at")
+            .in_("status", list(_PROCESSING_STATUSES))
+            .execute()
+        )
+    except Exception as e:
+        logger.warning(f"[Recovery] No se pudo consultar incidentes atascados: {e}")
+        return 0
+
+    for incident in response.data or []:
+        # Para executing/verifying la referencia es el momento de ejecución;
+        # para detected/investigating, el de creación.
+        reference = _parse_ts(incident.get("executed_at")) or _parse_ts(incident.get("created_at"))
+        if reference is None or reference > cutoff:
+            continue
+
+        try:
+            # Condicionado al estado leído: si el pipeline avanzó entre el
+            # SELECT y este UPDATE, no pisamos la transición legítima.
+            claim = (
+                supabase.table("incidents")
+                .update({"status": "failed", "action_error": _ORPHAN_NOTE})
+                .eq("id", incident["id"])
+                .eq("status", incident["status"])
+                .execute()
+            )
+            if claim.data:
+                record_event(incident["id"], "failed")
+                rescued += 1
+                logger.info(
+                    f"[Recovery] Incidente {incident['id'][:8]} rescatado "
+                    f"(atascado en '{incident['status']}')"
+                )
+        except Exception as e:
+            logger.warning(f"[Recovery] Error rescatando {incident['id'][:8]}: {e}")
+
+    return rescued
+
+
+_loop_started = False
+
+
+def start_recovery_loop() -> None:
+    """Lanza el sweep en un hilo daemon: una pasada al arrancar y luego periódica."""
+    global _loop_started
+    if _loop_started:
+        return
+    _loop_started = True
+
+    def _loop():
+        time.sleep(10)  # dejar que el arranque termine antes del primer sweep
+        while True:
+            try:
+                rescued = sweep_orphaned_incidents()
+                if rescued:
+                    logger.info(f"[Recovery] Sweep completado: {rescued} incidentes rescatados")
+            except Exception as e:
+                logger.warning(f"[Recovery] Sweep falló: {e}")
+            time.sleep(SWEEP_INTERVAL_SEC)
+
+    threading.Thread(target=_loop, name="sentinel-recovery", daemon=True).start()

--- a/Backend/tests/test_action_validators.py
+++ b/Backend/tests/test_action_validators.py
@@ -1,0 +1,131 @@
+"""
+Tests de los validadores de comandos de routers/actions.py.
+
+Esta es la superficie de seguridad más crítica del backend: todo comando que
+el ingeniero aprueba pasa por estos validadores antes de ejecutarse vía
+subprocess/SDK. Cubren los casos permitidos y los intentos de inyección.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-service-key")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-jwt-secret-min-32-characters-long")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+from routers.actions import (  # noqa: E402
+    _user_identity,
+    _validate_container_command,
+    _validate_kubernetes_command,
+    _validate_pg_command,
+)
+
+# ── Contenedores (docker / podman) ───────────────────────────────────────────
+
+class TestContainerValidator:
+    @pytest.mark.parametrize("command", [
+        "docker restart mi-app",
+        "docker logs mi-app",
+        "podman restart demo_crash",
+        "podman logs web.1",
+    ])
+    def test_allows_whitelisted_commands(self, command):
+        tokens = _validate_container_command(command)
+        assert len(tokens) == 3
+
+    @pytest.mark.parametrize("command", [
+        "docker rm mi-app",                          # subcomando destructivo
+        "docker exec mi-app sh",                     # exec arbitrario
+        "docker restart",                            # falta target
+        "docker restart app extra",                  # tokens de más
+        "kubectl restart mi-app",                    # binario no permitido
+        "rm -rf /",                                  # binario arbitrario
+        "docker restart app; rm -rf /",              # inyección con ;
+        "docker restart $(whoami)",                  # command substitution
+        "docker restart `id`",                       # backticks
+        "docker restart app && docker rm app",       # encadenamiento
+        "docker restart ../etc/passwd",              # path traversal en nombre
+        "docker restart -f",                         # flag en lugar de nombre
+    ])
+    def test_rejects_dangerous_commands(self, command):
+        with pytest.raises(HTTPException) as exc:
+            _validate_container_command(command)
+        assert exc.value.status_code == 400
+
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+
+class TestPgValidator:
+    @pytest.mark.parametrize("command,expected_func", [
+        ("pg_stat_activity sentinel_demo", "pg_stat_activity"),
+        ("pg_cancel_backend sentinel_demo", "pg_cancel_backend"),
+        ("pg_terminate_backend sentinel_demo", "pg_terminate_backend"),
+    ])
+    def test_allows_whitelisted_functions(self, command, expected_func):
+        func, datname = _validate_pg_command(command)
+        assert func == expected_func
+        assert datname == "sentinel_demo"
+
+    @pytest.mark.parametrize("command", [
+        "drop_database sentinel_demo",               # función no permitida
+        "pg_terminate_backend",                      # falta datname
+        "pg_terminate_backend db extra",             # tokens de más
+        "pg_terminate_backend db;drop",              # caracteres inválidos
+        "pg_terminate_backend 'db'--",               # intento de SQL injection
+    ])
+    def test_rejects_dangerous_commands(self, command):
+        with pytest.raises(HTTPException) as exc:
+            _validate_pg_command(command)
+        assert exc.value.status_code == 400
+
+
+# ── Kubernetes ────────────────────────────────────────────────────────────────
+
+class TestKubernetesValidator:
+    @pytest.mark.parametrize("command", [
+        "kubectl rollout restart deployment/web",
+        "kubectl rollout restart deployment/web -n staging",
+        "kubectl delete pod web-abc123",
+        "kubectl delete pod web-abc123 -n default",
+        "kubectl scale deployment/web --replicas=3",
+        "kubectl scale deployment/web --replicas=0 -n prod",
+    ])
+    def test_allows_whitelisted_commands(self, command):
+        tokens = _validate_kubernetes_command(command)
+        assert tokens[0] == "kubectl"
+
+    @pytest.mark.parametrize("command", [
+        "kubectl delete namespace prod",             # recurso no permitido
+        "kubectl delete pod web; rm -rf /",          # metacaracteres
+        "kubectl exec web -- sh",                    # exec arbitrario
+        "kubectl apply -f evil.yaml",                # apply arbitrario
+        "kubectl scale deployment/web --replicas=99",  # fuera de rango
+        "kubectl scale deployment/web --replicas=-1",  # negativo
+        "kubectl rollout restart statefulset/db",    # solo deployment
+        "kubectl delete pod web -n ns | tee /tmp/x",  # pipe
+        "kubectl delete pod $(whoami)",              # command substitution
+        "docker restart app",                        # binario incorrecto
+    ])
+    def test_rejects_dangerous_commands(self, command):
+        with pytest.raises(HTTPException) as exc:
+            _validate_kubernetes_command(command)
+        assert exc.value.status_code == 400
+
+
+# ── Auditoría ─────────────────────────────────────────────────────────────────
+
+class TestUserIdentity:
+    def test_prefers_email(self):
+        assert _user_identity({"email": "ing@empresa.com", "sub": "uuid-1"}) == "ing@empresa.com"
+
+    def test_falls_back_to_sub(self):
+        assert _user_identity({"sub": "uuid-1"}) == "uuid-1"
+
+    def test_unknown_when_empty(self):
+        assert _user_identity({}) == "unknown"

--- a/Backend/tests/test_webhook_auth.py
+++ b/Backend/tests/test_webhook_auth.py
@@ -1,0 +1,61 @@
+"""
+Tests de autenticación del webhook /api/alerts (ALERT_WEBHOOK_SECRET).
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-service-key")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-jwt-secret-min-32-characters-long")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+from main import app  # noqa: E402
+
+_EMPTY_WEBHOOK = {"status": "firing", "alerts": []}
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def with_secret(monkeypatch):
+    monkeypatch.setenv("ALERT_WEBHOOK_SECRET", "super-secreto")
+
+
+def test_rejects_without_header(client, with_secret):
+    response = client.post("/api/alerts", json=_EMPTY_WEBHOOK)
+    assert response.status_code == 401
+
+
+def test_rejects_wrong_secret(client, with_secret):
+    response = client.post(
+        "/api/alerts",
+        json=_EMPTY_WEBHOOK,
+        headers={"Authorization": "Bearer incorrecto"},
+    )
+    assert response.status_code == 401
+
+
+def test_accepts_correct_secret(client, with_secret):
+    response = client.post(
+        "/api/alerts",
+        json=_EMPTY_WEBHOOK,
+        headers={"Authorization": "Bearer super-secreto"},
+    )
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+def test_open_when_secret_not_configured(client, monkeypatch):
+    monkeypatch.delenv("ALERT_WEBHOOK_SECRET", raising=False)
+    response = client.post("/api/alerts", json=_EMPTY_WEBHOOK)
+    assert response.status_code == 200

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ LANGFUSE_HOST=http://localhost:3001
 LOKI_URL=http://localhost:3100
 CHROMA_HOST=http://localhost:8001
 PROMETHEUS_URL=http://localhost:9090
+
+# Secreto compartido del webhook /api/alerts (debe coincidir con
+# http_config.authorization.credentials en alertmanager/alertmanager.yml).
+# Si se omite, el webhook queda abierto (solo aceptable en desarrollo).
+ALERT_WEBHOOK_SECRET=sentinel-webhook-secret-change-me
+
+# CORS (opcional): orígenes permitidos separados por coma. Default: Vite dev server.
+# En producción: CORS_ORIGINS=https://sentinel-softserve-1.onrender.com
+# CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 ```
 
 **Frontend** — create `Frontend/.env.local`:
@@ -112,13 +121,20 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 VITE_API_URL=http://localhost:8000
 ```
 
-### 3. Start the infrastructure stack
+### 3. Database schema (new Supabase projects only)
+
+The schema lives in [`supabase/migrations/`](supabase/migrations/). For a fresh
+Supabase project, run the SQL files in order from the SQL Editor (or with
+`supabase db push`). The team's existing project already has the baseline
+schema — only apply `0002_production_hardening.sql` there.
+
+### 4. Start the infrastructure stack
 
 ```bash
 docker compose up -d
 ```
 
-### 4. Set up the backend
+### 5. Set up the backend
 
 ```bash
 cd Backend
@@ -127,7 +143,7 @@ source env/bin/activate      # Windows: env\Scripts\activate
 pip install -r requirements.txt
 ```
 
-### 5. Seed ChromaDB with runbooks (one time only)
+### 6. Seed ChromaDB with runbooks (one time only)
 
 ```bash
 cd Backend

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -13,6 +13,12 @@ receivers:
     webhook_configs:
       - url: "http://sentinel-backend:8000/api/alerts"
         send_resolved: true
+        # Debe coincidir con ALERT_WEBHOOK_SECRET del backend.
+        # Cambiar este valor en cualquier entorno que no sea demo local.
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: "sentinel-webhook-secret-change-me"
 
 inhibit_rules:
   # OOM Kill es la causa raíz — suprimir alarmas de síntomas del mismo contenedor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       LANGFUSE_HOST: "http://langfuse:3000"
       PROMETHEUS_URL: "http://prometheus:9090"
       ALERTMANAGER_URL: "http://alertmanager:9093"
+      # Secreto compartido del webhook /api/alerts. Debe coincidir con
+      # http_config.authorization.credentials en alertmanager/alertmanager.yml.
+      ALERT_WEBHOOK_SECRET: "sentinel-webhook-secret-change-me"
       PYTHONDONTWRITEBYTECODE: "1"   # evita __pycache__ en código fuente → no dispara WatchFiles
       # Socket de Podman: en Linux rootless el UID suele ser 1000.
       # Si el host usa un UID diferente, ajustar la ruta del volumen y esta variable.

--- a/supabase/migrations/0001_initial_schema.sql
+++ b/supabase/migrations/0001_initial_schema.sql
@@ -1,0 +1,64 @@
+-- ============================================================================
+-- 0001 — Esquema baseline de Sentinel
+--
+-- Reconstruido a partir del uso real en el código del backend (routers/ y
+-- services/). Si tu proyecto Supabase ya tiene estas tablas creadas desde el
+-- dashboard, NO ejecutes esta migración ahí: valida con
+--   supabase db pull
+-- que el esquema remoto coincida, y usa este archivo como referencia para
+-- instalaciones nuevas (self-hosted / otros entornos).
+-- ============================================================================
+
+create extension if not exists "pgcrypto";
+
+-- ── incidents ───────────────────────────────────────────────────────────────
+create table if not exists public.incidents (
+    id                      uuid primary key default gen_random_uuid(),
+    title                   text not null,
+    target                  text not null,
+    severity                text not null check (severity in ('critical', 'high', 'medium', 'low')),
+    status                  text not null default 'detected' check (status in (
+                                'detected', 'investigating', 'analyzed', 'awaiting_approval',
+                                'executing_solution', 'verifying', 'resolved', 'failed'
+                            )),
+    source_type             text not null default 'container' check (source_type in ('container', 'database', 'manual')),
+    container_runtime       text check (container_runtime in ('docker', 'podman', 'kubernetes')),
+    incident_type           text,
+    logs                    text,
+    server_name             text,
+    agent_reasoning         text,
+    proposed_action         text,
+    action_result           text,
+    action_error            text,
+    metrics_snapshot        jsonb,
+    post_mortem_md          text,
+    post_mortem_updated_at  timestamptz,
+    executed_at             timestamptz,
+    resolved_at             timestamptz,
+    created_at              timestamptz not null default now(),
+    updated_at              timestamptz
+);
+
+create index if not exists idx_incidents_status     on public.incidents (status);
+create index if not exists idx_incidents_target     on public.incidents (target);
+create index if not exists idx_incidents_created_at on public.incidents (created_at desc);
+
+-- ── incident_events (timeline append-only de transiciones de estado) ───────
+create table if not exists public.incident_events (
+    id          uuid primary key default gen_random_uuid(),
+    incident_id uuid not null references public.incidents (id) on delete cascade,
+    status      text not null,
+    created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_incident_events_incident_id
+    on public.incident_events (incident_id, created_at);
+
+-- ── Realtime (el frontend escucha cambios en incidents) ────────────────────
+do $$
+begin
+    alter publication supabase_realtime add table public.incidents;
+exception
+    when duplicate_object then null;
+    when undefined_object then null;
+end $$;

--- a/supabase/migrations/0002_production_hardening.sql
+++ b/supabase/migrations/0002_production_hardening.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- 0002 — Endurecimiento para producción
+--
+-- 1. approved_by: registra quién aprobó/rechazó/pospuso la acción propuesta
+--    (auditoría human-in-the-loop).
+-- 2. fingerprint: clave de deduplicación que envía Alertmanager en cada
+--    alerta. El índice único parcial garantiza a nivel de base de datos que
+--    no existan dos incidentes ACTIVOS con el mismo fingerprint, eliminando
+--    la race condition del check-then-insert en el backend.
+--
+-- Esta migración SÍ es segura de ejecutar sobre el proyecto Supabase
+-- existente (solo agrega columnas e índices).
+-- ============================================================================
+
+alter table public.incidents add column if not exists approved_by text;
+alter table public.incidents add column if not exists fingerprint text;
+
+-- Único entre incidentes activos: un fingerprint puede repetirse en el
+-- histórico (incidentes resueltos/fallidos) pero no entre los vivos.
+create unique index if not exists uniq_incidents_active_fingerprint
+    on public.incidents (fingerprint)
+    where fingerprint is not null
+      and status not in ('resolved', 'failed');


### PR DESCRIPTION
## Resumen

Correcciones de la revisión de preparación para producción de Sentinel:

### Seguridad
- **Webhook `/api/alerts` autenticado**: exige `Authorization: Bearer <ALERT_WEBHOOK_SECRET>`. Sin la env var queda abierto (modo dev) con warning en logs. Alertmanager envía el secreto vía `http_config.authorization`.
- **Auditoría human-in-the-loop**: execute/reject/postpone registran `approved_by` (email del JWT).
- **Transiciones atómicas**: el claim de `awaiting_approval` es un UPDATE condicional — dos aprobaciones simultáneas ya no ejecutan el comando dos veces (la segunda recibe 409).

### Robustez
- **Deduplicación por fingerprint** de Alertmanager, respaldada por índice único parcial en Postgres (elimina la race del check-then-insert).
- **Recovery sweep**: incidentes huérfanos por reinicios del backend (atascados en `detected`/`investigating`/`executing_solution`/`verifying` >30 min) se marcan `failed` con nota explicativa. Corre al arrancar y cada 15 min.

### Bugs y configuración
- **Fix**: los endpoints de runbooks e incidentes similares para K8s/Podman consultaban las colecciones de Docker.
- **CORS por entorno**: `CORS_ORIGINS` / `CORS_ORIGIN_REGEX` (necesario para que el frontend de Render funcione sin hardcodear orígenes).
- **Migraciones SQL versionadas** en `supabase/migrations/` (baseline reconstruido + hardening).

### Tests
- 40+ tests nuevos: validadores de comandos (inyección con `;`, `$()`, backticks, pipes, path traversal) y auth del webhook. **76 passing**, ruff limpio.

## Pasos post-merge (manuales)

1. Ejecutar `supabase/migrations/0002_production_hardening.sql` en el SQL Editor de Supabase (solo `ADD COLUMN IF NOT EXISTS` + índice; seguro sobre datos existentes).
2. En Render (backend): configurar `CORS_ORIGINS=https://sentinel-softserve-1.onrender.com` y un `ALERT_WEBHOOK_SECRET` fuerte.
3. Verificar: `POST /api/alerts` sin header → 401; con el secreto → 200.

